### PR TITLE
Compilation fails when model contains a chooser with a list literal as the default 

### DIFF
--- a/src/main/api/LogoList.scala
+++ b/src/main/api/LogoList.scala
@@ -2,6 +2,7 @@
 
 package org.nlogo.api
 
+import org.nlogo.core.{ LogoList => CoreLogoList }
 import collection.immutable.{ Vector, VectorBuilder }
 import language.implicitConversions
 
@@ -20,7 +21,7 @@ object LogoList {
 }
 
 class LogoList private (private val v: Vector[AnyRef])
-extends java.util.AbstractSequentialList[AnyRef] with Serializable {
+extends java.util.AbstractSequentialList[AnyRef] with Serializable with CoreLogoList {
 
   def scalaIterator = v.iterator
   def toVector = v
@@ -34,6 +35,10 @@ extends java.util.AbstractSequentialList[AnyRef] with Serializable {
   override def listIterator(i: Int): java.util.ListIterator[AnyRef] =
     new Iterator(v.drop(i))
   override def add(index: Int, obj: AnyRef) = unsupported
+
+  /// methods required by CoreLogoList
+
+  override def toList: List[AnyRef] = scalaIterator.toList
 
   /// public methods for prims. input validity checking is caller's job
 

--- a/src/main/core/LogoList.scala
+++ b/src/main/core/LogoList.scala
@@ -1,0 +1,7 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.core
+
+trait LogoList {
+  def toList: List[AnyRef]
+}

--- a/src/main/core/Widget.scala
+++ b/src/main/core/Widget.scala
@@ -17,7 +17,8 @@ sealed trait DeclaresGlobalCommand {
   def asNetLogoString(x: Any): String = x match {
     case s: String => s""""$s""""
     case b: Boolean => if(b) "true" else "false"
-    case l: List[Any] => "[" + l.map(asNetLogoString).mkString(" ") + "]"
+    case l: List[Any] => l.map(asNetLogoString).mkString("[", " ", "]")
+    case ll: LogoList => ll.toList.map(asNetLogoString).mkString("[" , " ", "]")
     case o: AnyRef => o.toString
   }
   def command: String = "set " + varName + " " + asNetLogoString(default)

--- a/src/test/core/WidgetTests.scala
+++ b/src/test/core/WidgetTests.scala
@@ -1,0 +1,20 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.core
+
+import org.scalatest.FunSuite
+
+class WidgetTests extends FunSuite {
+  test("Chooser handles choices with lists") {
+    val l = new LogoList {
+      val toList = List(1, 2, 3).map(_.toDouble).asInstanceOf[List[AnyRef]]
+      override def toString: String = toList.toString()
+    }
+
+    val chooser = Chooser(
+      display = "FOOBAR",
+      varName = "FOOBAR",
+      choices = List(l, 4.toDouble).asInstanceOf[List[AnyRef]])
+    assertResult("[[1.0 2.0 3.0] 4.0]")(chooser.constraint(1))
+  }
+}


### PR DESCRIPTION
Originally posted as https://github.com/NetLogo/Tortoise/issues/111

To reproduce:
1. Create a model.
2. Add a chooser.
3. Add `[1 2 3]` as an option.
4. Select `[1 2 3]` and save so that it's the default.
5. Attempt to compile the model with Tortoise. (`CompiledModel.fromNlogoContents` is the easiest, but you could use `Compiler` directly too)

Result: `Expected a literal value.`

It works totally fine when the list literal is anything but the default value. It's completely usable by the model and such. We must be parsing the defaults differently I guess.
