### PR TITLE
Monitor's `rawDisplay` should be `display`

### DIFF
--- a/src/main/api/model/WidgetReader.scala
+++ b/src/main/api/model/WidgetReader.scala
@@ -402,7 +402,7 @@ object MonitorReader extends BaseWidgetReader {
                         ReservedLine(),
                         IntLine()    // font size
                       )
-  def asList(monitor: Monitor) = List((), monitor.left, monitor.top, monitor.right, monitor.bottom, monitor.rawDisplay,
+  def asList(monitor: Monitor) = List((), monitor.left, monitor.top, monitor.right, monitor.bottom, monitor.display,
     monitor.source, monitor.precision, (), monitor.fontSize)
   def asWidget(vals: List[Any]): Monitor = {
     val List(_, left: Int, top: Int, right: Int, bottom: Int, rawDisplay: Option[String] @unchecked,

--- a/src/main/core/Widget.scala
+++ b/src/main/core/Widget.scala
@@ -95,10 +95,9 @@ case class Slider(display: String, left: Int = 0, top: Int = 0, right: Int = 0, 
              extends Widget with DeclaresGlobal with DeclaresGlobalCommand with DeclaresConstraint {
   override def constraint = NumericConstraintSpecification(default)
 }
-case class Monitor(rawDisplay: Option[String], left: Int, top: Int, right: Int, bottom: Int,
-             source: String, precision: Int, fontSize: Int) extends Widget {
-  def display = rawDisplay getOrElse source
-}
+case class Monitor(display: Option[String], left: Int, top: Int, right: Int, bottom: Int,
+             source: String, precision: Int, fontSize: Int) extends Widget
+
 case class Output(left: Int, top: Int, right: Int, bottom: Int, fontSize: Int) extends Widget
 
 sealed abstract class InputBoxType(val name:String)

--- a/src/test/api/model/WidgetTest.scala
+++ b/src/test/api/model/WidgetTest.scala
@@ -233,7 +233,7 @@ class WidgetTest extends FunSuite {
     assert(MonitorReader.validate(MonitorReader.format(MonitorReader.parse(monitor)).split("\n").toList))
     assert(Monitor(None, 74, 214, 152, 259, "count sheep", 3, 11) ==
       MonitorReader.parse(MonitorReader.format(MonitorReader.parse(monitor)).split("\n").toList))
-    assert("count sheep" == MonitorReader.parse(monitor).display)
+    assert(None == MonitorReader.parse(monitor).display)
   }
 
   test("switch") {


### PR DESCRIPTION
In #15, I thought Button was the only that did this, but apparently Monitor does too. Sorry about that!
