### PR TITLE
Widget characters should not be escaped in their internal representation

### DIFF
--- a/src/main/api/model/WidgetReader.scala
+++ b/src/main/api/model/WidgetReader.scala
@@ -167,7 +167,7 @@ object ButtonReader extends BaseWidgetReader {
                         IntLine(),  // right
                         IntLine(),  // bottom
                         OptionLine[String]("NIL", StringLine()),   // rawDisplay
-                        StringLine(),   // code to execute
+                        EscapedStringLine(),   // code to execute
                         TNilBooleanLine(),  // forever?
                         ReservedLine(),
                         ReservedLine(),
@@ -397,7 +397,7 @@ object MonitorReader extends BaseWidgetReader {
                         IntLine(),  // right
                         IntLine(),  // bottom
                         OptionLine[String]("NIL", StringLine()),   // rawDisplay
-                        StringLine(),   // source
+                        EscapedStringLine(),   // source
                         IntLine(),   // precision
                         ReservedLine(),
                         IntLine()    // font size

--- a/src/test/api/model/WidgetTest.scala
+++ b/src/test/api/model/WidgetTest.scala
@@ -140,6 +140,32 @@ class WidgetTest extends FunSuite {
       ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
     assert(None == ButtonReader.parse(button).display)
   }
+
+  test("button escaped source") {
+    val button = """|BUTTON
+                    |202
+                    |101
+                    |271
+                    |134
+                    |NIL
+                    |\"bar\"
+                    |T
+                    |1
+                    |T
+                    |OBSERVER
+                    |NIL
+                    |NIL
+                    |NIL
+                    |NIL
+                    |1""".stripMargin.split("\n").toList
+    assert(ButtonReader.validate(button))
+    assert(Button(None,202,101,271,134,"\"bar\"",true) == ButtonReader.parse(button))
+    assert(ButtonReader.validate(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
+    assert(Button(None,202,101,271,134,"\"bar\"",true) ==
+      ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
+    assert(None == ButtonReader.parse(button).display)
+  }
+
   test("slider") {
      val slider = """|SLIDER
                      |20
@@ -232,6 +258,25 @@ class WidgetTest extends FunSuite {
     assert(Monitor(None, 74, 214, 152, 259, "count sheep", 3, 11) == MonitorReader.parse(monitor))
     assert(MonitorReader.validate(MonitorReader.format(MonitorReader.parse(monitor)).split("\n").toList))
     assert(Monitor(None, 74, 214, 152, 259, "count sheep", 3, 11) ==
+      MonitorReader.parse(MonitorReader.format(MonitorReader.parse(monitor)).split("\n").toList))
+    assert(None == MonitorReader.parse(monitor).display)
+  }
+
+  test("monitor nil display escaped source") {
+    val monitor = """|MONITOR
+                     |74
+                     |214
+                     |152
+                     |259
+                     |NIL
+                     |\"foo\"
+                     |3
+                     |1
+                     |11""".stripMargin.split("\n").toList
+    assert(MonitorReader.validate(monitor))
+    assert(Monitor(None, 74, 214, 152, 259, "\"foo\"", 3, 11) == MonitorReader.parse(monitor))
+    assert(MonitorReader.validate(MonitorReader.format(MonitorReader.parse(monitor)).split("\n").toList))
+    assert(Monitor(None, 74, 214, 152, 259, "\"foo\"", 3, 11) ==
       MonitorReader.parse(MonitorReader.format(MonitorReader.parse(monitor)).split("\n").toList))
     assert(None == MonitorReader.parse(monitor).display)
   }


### PR DESCRIPTION
#19 is back and badder than ever. Looks like quotes around strings are being escaped in internal representations of widget code. So, a monitor with the reporter `"foo"` will have its source represented as `"\\\"foo\\\""` instead of `"\"foo\""`. Same goes for buttons. Didn't seem like any other widgets were affected. The only other widgets that has actual code associated with it are plot pens, and they do not suffer from the problem. Also, `display` strings don't suffer from the problem. Here's a model:

https://gist.github.com/qiemem/0415f8ccfb96e2e224e4

The fix is to just unescape things when they're read in from the file, so that the widget case classes end up with unescaped versions. Right now, these strings are written to nlogo files escaped, which doesn't really make sense, but needs to stay that way for backwards compatibility.

It contains a monitor and button showing the problem and a plot not showing the problem. I'm like 10,000% sure this is the cause of NetLogo/Galapagos#187.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/netlogo-headless/28)

<!-- Reviewable:end -->
