### PR TITLE
Break dependency between language testing and headless workspace

### DIFF
--- a/project/Depend.scala
+++ b/project/Depend.scala
@@ -69,10 +69,11 @@ object Depend {
       "drawing" -> List("api"),
       "generate" -> List("prim"),
       "headless" -> List("mirror", "workspace"),
-      "headless/lang" -> List("headless"),
+      "headless/lang" -> List("headless", "headless/test"),
       "headless/lang/misc" -> List("headless/lang"),
       "headless/misc" -> List("headless"),
       "headless/render" -> List("headless"),
+      "headless/test" -> List("api"),
       "job" -> List("nvm"),
       "lab" -> List("nvm"),
       "lex" -> List("core"),
@@ -143,7 +144,7 @@ check [ASM-free-zone] independentOf org.objectweb.*
 [XML-free-zone] = org.nlogo.* excluding [lab]
 check [XML-free-zone] independentOf [xml]
 
-[reflections-free-zone] = org.nlogo.* excluding org.nlogo.headless.lang.*
+[reflections-free-zone] = org.nlogo.* excluding org.nlogo.headless.lang.* org.nlogo.headless.test.*
 check [reflections-free-zone] independentOf [reflections]
 
 [parser-combinator-free-zone] = org.nlogo.* excluding org.nlogo.parse.StructureCombinators* org.nlogo.parse.SeqReader* org.nlogo.parse.Cleanup

--- a/src/test/headless/lang/Finder.scala
+++ b/src/test/headless/lang/Finder.scala
@@ -4,6 +4,8 @@ package org.nlogo.headless
 package lang
 
 import java.io.File
+import org.nlogo.headless.test.{Finder => TestFinder, ExtensionTests, ModelTests, ReporterTests, CommandTests,
+                                AbstractFixture, TestMode, Reporter, Command, Declaration, Open, LanguageTest}
 import org.scalatest.{ FunSuite, Tag }
 
 import
@@ -12,125 +14,12 @@ import
     core.{ Model, Resource },
     util.SlowTest
 
-/// top level entry points
-
-class TestCommands extends Finder {
-  override def files =
-    TxtsInResources("commands")
-}
-class TestReporters extends Finder {
-  override def files =
-    TxtsInResources("reporters")
-}
-class TestModels extends Finder {
-  override def files =
-    TxtsInDir("models/test")
-}
-class TestExtensions extends Finder {
-  override def files = new Iterable[(String, String)] {
-    override def iterator = {
-      def filesInDir(parent: File): Iterable[File] =
-        parent.listFiles.flatMap{f =>
-          if(f.isDirectory)
-            filesInDir(f)
-          else
-            List(f).filter(_.getName == "tests.txt")}
-      filesInDir(new File("extensions"))
-        .iterator
-        .map(f => (suiteName(f), file2String(f.getAbsolutePath)))
-    }
-  }
-}
-
-/// common infrastructure
-
-// don't use FixtureSuite here because we may need two fixtures, not just
-// one, and FixtureSuite assumes one - ST 8/7/13
-
-trait Finder extends FunSuite with SlowTest {
-  def files: Iterable[(String, String)]
-  def suiteName(f: File): String =
-    if (f.getName == "tests.txt")
-      f.getParentFile.getName
-    else
-      f.getName.stripSuffix(".txt")
-  case class TxtsInDir(dir: String) extends Iterable[(String, String)] {
-    override def iterator =
-      new File(dir).listFiles
-        .filter(_.getName.endsWith(".txt"))
-        .filterNot(_.getName.containsSlice("SDM"))
-        .filterNot(_.getName.containsSlice("HubNet"))
-        .iterator
-        .map(f => (suiteName(f), file2String(f.getAbsolutePath)))
-  }
-  case class TxtsInResources(path: String) extends Iterable[(String, String)] {
-    import org.reflections._
-    import collection.JavaConverters._
-    override def iterator =
-      new Reflections(path, new scanners.ResourcesScanner())
-        .getResources(java.util.regex.Pattern.compile(".*\\.txt"))
-        .asScala.toSeq.sorted.iterator
-        .map(s =>
-          (s.stripPrefix(path + "/").stripSuffix(".txt"),
-           Resource.asString("/" + s)))
-  }
-  // parse tests first, then run them
-  for (t <- files.flatMap(Function.tupled(parseFile)))
-    // by tagging each test with both its suite name and its full name,
-    // we support both e.g. `tc Lists` and `tc Lists::Remove`
-    test(t.fullName, new Tag(t.suiteName){}, new Tag(t.fullName){}) {
-      for (mode <- t.modes)
-        if (shouldRun(t, mode))
-          runTest(t, mode)
-    }
-  def withFixture[T](name: String)(body: AbstractFixture => T): T =
+trait Finder extends TestFinder {
+  override def withFixture[T](name: String)(body: AbstractFixture => T): T =
     Fixture.withFixture(name)(body)
-  def runTest(t: LanguageTest, mode: TestMode) {
-    withFixture(s"${t.fullName} ($mode)") {
-      fixture =>
-        val nonDecls = t.entries.filterNot(_.isInstanceOf[Declaration])
-        val decls =
-          t.entries.collect{case d: Declaration => d.source}
-            .mkString("\n").trim
-        if (nonDecls.forall(!_.isInstanceOf[Open]))
-          fixture.open(new Model(
-            code = decls,
-            widgets = StandardWidgets))
-        else
-          assert(t.entries.forall(!_.isInstanceOf[Declaration]))
-        nonDecls.foreach{
-          case Open(path) =>
-            fixture.open(path)
-          case command: Command =>
-            fixture.runCommand(command, mode)
-          case reporter: Reporter =>
-            fixture.runReporter(reporter, mode)
-          case _ =>
-            throw new IllegalStateException
-        }
-    }
-  }
-  def parseFile(suiteName: String, contents: String): List[LanguageTest] = {
-    def preprocessStackTraces(s: String) =
-      s.replace("\\\n  ", "\\n")
-    Parser.parse(suiteName, preprocessStackTraces(contents))
-  }
-  // on the core branch the _3D tests are gone, but extensions tests still have them since we
-  // didn't branch the extensions, so we still need to filter those out - ST 1/13/12
-  def shouldRun(t: LanguageTest, mode: TestMode) =
-    !t.testName.endsWith("_3D") && {
-      import api.Version.useGenerator
-      if (t.testName.startsWith("Generator"))
-        useGenerator
-      else if (t.testName.startsWith("NoGenerator"))
-        !useGenerator
-      else true
-    }
-  val StandardWidgets = {
-    import core.{ Plot, Pen, View }
-    List(
-      View.square(5),
-      Plot(display = "plot1", pens = List(Pen(display = "pen1"), Pen(display = "pen2"))),
-      Plot(display = "plot2", pens = List(Pen(display = "pen1"), Pen(display = "pen2"))))
-  }
 }
+
+class TestCommands extends CommandTests with Finder
+class TestReporters extends ReporterTests with Finder
+class TestModels extends ModelTests with Finder
+class TestExtensions extends ExtensionTests with Finder

--- a/src/test/headless/lang/Fixture.scala
+++ b/src/test/headless/lang/Fixture.scala
@@ -8,6 +8,8 @@ import org.nlogo.{ api, agent, core }
 import org.nlogo.core.{CompilerException, Femto, Model, View}
 import CompilerException.{RuntimeErrorAtCompileTimePrefix => runtimePrefix}
 import org.nlogo.nvm.CompilerInterface
+import org.nlogo.headless.test.{RunMode, NormalMode, TestMode, CompileError,
+                                Success, Result, Reporter, Command, AbstractFixture, RuntimeError, StackTrace}
 
 trait FixtureSuite extends scalatest.fixture.FunSuite {
   type FixtureParam = Fixture
@@ -22,33 +24,6 @@ object Fixture {
     val fixture = new Fixture(name)
     try fn(fixture)
     finally fixture.workspace.dispose()
-  }
-}
-
-// implemented below via HeadlessWorkspace, but also to be implemented
-// elsewhere by Tortoise - ST 8/28/13
-trait AbstractFixture {
-  import Assertions._
-  def defaultView: core.View
-  def declare(code: String): Unit = declare(Model(code = code, widgets = List(defaultView)))
-  def declare(model: Model = Model(widgets = List(defaultView)))
-  def open(path: String)
-  def open(model: Model)
-  def runCommand(command: Command, mode: TestMode)
-  def runReporter(reporter: Reporter, mode: TestMode)
-  def readFromString(literal: String): AnyRef
-  def checkResult(mode: TestMode, reporter: String, expectedResult: String, actualResult: AnyRef) {
-    // To be as safe as we can, let's do two separate checks here...  we'll compare the results both
-    // as values and as printed representations.  Most of the time these checks will come out
-    // the same, but it might be good to have both, partially as a way of giving both Equality and
-    // Dump lots of testing! - ST 5/8/03, 8/21/13
-    withClue(s"""$mode: not equals(): reporter "$reporter" """) {
-      assertResult(expectedResult)(
-        api.Dump.logoObject(actualResult, true, false))
-    }
-    assert(api.Equality.equals(actualResult,
-      readFromString(expectedResult)),
-      s"""$mode: not recursivelyEqual(): reporter "$reporter" """)
   }
 }
 

--- a/src/test/headless/lang/misc/TestProfiler.scala
+++ b/src/test/headless/lang/misc/TestProfiler.scala
@@ -12,6 +12,7 @@ package misc
 // This would be nicer looking if it were done using Josh's model testing DSL.  (At the time I made
 // this, the DSL didn't support catching runtime errors, but now it does.) - ST 5/4/10
 
+import org.nlogo.headless.test.RuntimeError
 import org.nlogo.util.SlowTest
 import org.nlogo.api
 import org.nlogo.core.Model

--- a/src/test/headless/test/AbstractFixture.scala
+++ b/src/test/headless/test/AbstractFixture.scala
@@ -1,0 +1,34 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.headless.test
+
+import org.nlogo.core.Model
+import org.nlogo.{api, core}
+import org.scalatest.Assertions
+
+// implemented by HeadlessWorkspace in org.nlogo.headless.lang, implemented
+// elsewhere by Tortoise - ST 8/28/13, RG 1/26/15
+trait AbstractFixture {
+  import org.scalatest.Assertions._
+  def defaultView: core.View
+  def declare(code: String): Unit = declare(Model(code = code, widgets = List(defaultView)))
+  def declare(model: Model = Model(widgets = List(defaultView)))
+  def open(path: String)
+  def open(model: Model)
+  def runCommand(command: Command, mode: TestMode)
+  def runReporter(reporter: Reporter, mode: TestMode)
+  def readFromString(literal: String): AnyRef
+  def checkResult(mode: TestMode, reporter: String, expectedResult: String, actualResult: AnyRef) {
+    // To be as safe as we can, let's do two separate checks here...  we'll compare the results both
+    // as values and as printed representations.  Most of the time these checks will come out
+    // the same, but it might be good to have both, partially as a way of giving both Equality and
+    // Dump lots of testing! - ST 5/8/03, 8/21/13
+    withClue(s"""$mode: not equals(): reporter "$reporter" """) {
+      assertResult(expectedResult)(
+        api.Dump.logoObject(actualResult, true, false))
+    }
+    assert(api.Equality.equals(actualResult,
+      readFromString(expectedResult)),
+      s"""$mode: not recursivelyEqual(): reporter "$reporter" """)
+  }
+}

--- a/src/test/headless/test/Finder.scala
+++ b/src/test/headless/test/Finder.scala
@@ -1,0 +1,136 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.headless.test
+
+import java.io.File
+import org.nlogo.util.SlowTest
+import org.scalatest.{ FunSuite, Tag }
+
+import
+  org.nlogo.{ api, core },
+    api.FileIO.file2String,
+    core.{ Model, Resource }
+
+/// top level entry points
+
+abstract class CommandTests extends Finder {
+  override def files =
+    TxtsInResources("commands")
+}
+abstract class ReporterTests extends Finder {
+  override def files =
+    TxtsInResources("reporters")
+}
+abstract class ModelTests extends Finder {
+  override def files =
+    TxtsInDir("models/test")
+}
+abstract class ExtensionTests extends Finder {
+  override def files = new Iterable[(String, String)] {
+    override def iterator = {
+      def filesInDir(parent: File): Iterable[File] =
+        parent.listFiles.flatMap{f =>
+          if(f.isDirectory)
+            filesInDir(f)
+          else
+            List(f).filter(_.getName == "tests.txt")}
+      filesInDir(new File("extensions"))
+        .iterator
+        .map(f => (suiteName(f), file2String(f.getAbsolutePath)))
+    }
+  }
+}
+
+
+/// common infrastructure
+
+// don't use FixtureSuite here because we may need two fixtures, not just
+// one, and FixtureSuite assumes one - ST 8/7/13
+trait Finder extends FunSuite with SlowTest {
+  def files: Iterable[(String, String)]
+  def suiteName(f: File): String =
+    if (f.getName == "tests.txt")
+      f.getParentFile.getName
+    else
+      f.getName.stripSuffix(".txt")
+  case class TxtsInDir(dir: String) extends Iterable[(String, String)] {
+    override def iterator =
+      new File(dir).listFiles
+        .filter(_.getName.endsWith(".txt"))
+        .filterNot(_.getName.containsSlice("SDM"))
+        .filterNot(_.getName.containsSlice("HubNet"))
+        .iterator
+        .map(f => (suiteName(f), file2String(f.getAbsolutePath)))
+  }
+  case class TxtsInResources(path: String) extends Iterable[(String, String)] {
+    import org.reflections._
+    import collection.JavaConverters._
+    override def iterator =
+      new Reflections(path, new scanners.ResourcesScanner())
+        .getResources(java.util.regex.Pattern.compile(".*\\.txt"))
+        .asScala.toSeq.sorted.iterator
+        .map(s =>
+          (s.stripPrefix(path + "/").stripSuffix(".txt"),
+           Resource.asString("/" + s)))
+  }
+  // parse tests first, then run them
+  for (t <- files.flatMap(Function.tupled(parseFile)))
+    // by tagging each test with both its suite name and its full name,
+    // we support both e.g. `tc Lists` and `tc Lists::Remove`
+    test(t.fullName, new Tag(t.suiteName){}, new Tag(t.fullName){}) {
+      for (mode <- t.modes)
+        if (shouldRun(t, mode))
+          runTest(t, mode)
+    }
+
+  def withFixture[T](name: String)(body: AbstractFixture => T): T
+
+  def runTest(t: LanguageTest, mode: TestMode) {
+    withFixture(s"${t.fullName} ($mode)") {
+      fixture =>
+        val nonDecls = t.entries.filterNot(_.isInstanceOf[Declaration])
+        val decls =
+          t.entries.collect{case d: Declaration => d.source}
+            .mkString("\n").trim
+        if (nonDecls.forall(!_.isInstanceOf[Open]))
+          fixture.open(new Model(
+            code = decls,
+            widgets = StandardWidgets))
+        else
+          assert(t.entries.forall(!_.isInstanceOf[Declaration]))
+        nonDecls.foreach{
+          case Open(path) =>
+            fixture.open(path)
+          case command: Command =>
+            fixture.runCommand(command, mode)
+          case reporter: Reporter =>
+            fixture.runReporter(reporter, mode)
+          case _ =>
+            throw new IllegalStateException
+        }
+    }
+  }
+  def parseFile(suiteName: String, contents: String): List[LanguageTest] = {
+    def preprocessStackTraces(s: String) =
+      s.replace("\\\n  ", "\\n")
+    Parser.parse(suiteName, preprocessStackTraces(contents))
+  }
+  // on the core branch the _3D tests are gone, but extensions tests still have them since we
+  // didn't branch the extensions, so we still need to filter those out - ST 1/13/12
+  def shouldRun(t: LanguageTest, mode: TestMode) =
+    !t.testName.endsWith("_3D") && {
+      import api.Version.useGenerator
+      if (t.testName.startsWith("Generator"))
+        useGenerator
+      else if (t.testName.startsWith("NoGenerator"))
+        !useGenerator
+      else true
+    }
+  val StandardWidgets = {
+    import core.{ Plot, Pen, View }
+    List(
+      View.square(5),
+      Plot(display = "plot1", pens = List(Pen(display = "pen1"), Pen(display = "pen2"))),
+      Plot(display = "plot2", pens = List(Pen(display = "pen1"), Pen(display = "pen2"))))
+  }
+}

--- a/src/test/headless/test/LanguageTest.scala
+++ b/src/test/headless/test/LanguageTest.scala
@@ -1,7 +1,6 @@
 // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
 
-package org.nlogo.headless
-package lang
+package org.nlogo.headless.test
 
 import org.nlogo.core.AgentKind
 

--- a/src/test/headless/test/Parser.scala
+++ b/src/test/headless/test/Parser.scala
@@ -1,10 +1,9 @@
 // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
 
-package org.nlogo.headless
-package lang
+package org.nlogo.headless.test
 
-import org.nlogo.{ core, api },
-  core.{Keywords, AgentKind}
+import org.nlogo.core
+import org.nlogo.core.{AgentKind, Keywords}
 
 object Parser {
 

--- a/src/test/headless/test/ParserTests.scala
+++ b/src/test/headless/test/ParserTests.scala
@@ -1,9 +1,8 @@
 // (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
 
-package org.nlogo.headless.lang
+package org.nlogo.headless.test
 
 import org.scalatest.FunSuite
-import org.nlogo.core.AgentKind
 
 class ParserTests extends FunSuite {
 


### PR DESCRIPTION
Move code shared with tortoise out into`org.nlogo.headless.test`. This package name can be adjusted/moved if desired. Needed for https://github.com/NetLogo/Tortoise/pull/125.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/netlogo/netlogo-headless/33)
<!-- Reviewable:end -->
