### PR TITLE
Wip scalajs 6

### DIFF
--- a/nightly.sh
+++ b/nightly.sh
@@ -25,13 +25,13 @@ echo "*** done: test:compile"
 if [ ${PIPESTATUS[0]} -ne 0 ] ; then echo "*** FAILED: fast:test"; exit 1; fi
 echo "*** done: fast:test"
 
-./sbt parserJvm/test 2>&1 | tee tmp/nightly/0-parser-jvm-test.txt
-if [ ${PIPESTATUS[0]} -ne 0 ] ; then echo "*** FAILED: parserJvm/test"; exit 1; fi
-echo "*** done: parserJvm/test"
+./sbt parserJVM/test 2>&1 | tee tmp/nightly/0-parser-jvm-test.txt
+if [ ${PIPESTATUS[0]} -ne 0 ] ; then echo "*** FAILED: parserJVM/test"; exit 1; fi
+echo "*** done: parserJVM/test"
 
-./sbt parserJs/test 2>&1 | tee tmp/nightly/0-parser-js-test.txt
-if [ ${PIPESTATUS[0]} -ne 0 ] ; then echo "*** FAILED: parserJs/test"; exit 1; fi
-echo "*** done: parserJs/test"
+./sbt parserJS/test 2>&1 | tee tmp/nightly/0-parser-js-test.txt
+if [ ${PIPESTATUS[0]} -ne 0 ] ; then echo "*** FAILED: parserJS/test"; exit 1; fi
+echo "*** done: parserJS/test"
 
 ./sbt jvmBuild/nogen jvmBuild/fast:test 2>&1 | tee tmp/nightly/1-nogen-fast-test.txt
 if [ ${PIPESTATUS[0]} -ne 0 ] ; then echo "*** FAILED: nogen fast:test"; exit 1; fi

--- a/parser-core/src/main/core/ExtensionManager.scala
+++ b/parser-core/src/main/core/ExtensionManager.scala
@@ -14,7 +14,7 @@ trait ExtensionManager {
    * "live", or currently in the block, so that its primitives are available for use
    * elsewhere in the model.
    *
-   * See the top of {@link org.nlogo.workspace.ExtensionManager} for full details.
+   * See the top of org.nlogo.workspace.ExtensionManager for full details.
    */
   def startFullCompilation()
 
@@ -23,7 +23,7 @@ trait ExtensionManager {
    * current compile to shut down. Should be called during each full
    * re-compile.
    *
-   * See the top of {@link org.nlogo.workspace.ExtensionManager} for full details.
+   * See the top of org.nlogo.workspace.ExtensionManager for full details.
    */
   def finishFullCompilation()
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,9 +26,7 @@ resolvers += Resolver.url(
     url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
         Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.scala-lang.modules.scalajs" % "scalajs-sbt-plugin" % "0.5.5")
-
-addSbtPlugin("com.lihaoyi" % "utest-js-plugin" % "0.2.4")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.2")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.2")
 


### PR DESCRIPTION
This upgrades to scala.js 0.6.2. I have an [upgraded version of Tortoise](https://github.com/NetLogo/Tortoise/tree/wip-scalajs-6) as well. If desired, I could make the upgraded version part of the [javascript-compiler PR](https://github.com/NetLogo/Tortoise/pull/129).