### PR TITLE
Regression: Namer chokes on acceptable identifier names containing numbers

### DIFF
--- a/jvm/resources/test/commands/Let.txt
+++ b/jvm/resources/test/commands/Let.txt
@@ -3,6 +3,11 @@ LetSimple
   O> let x 5 set glob1 x
   glob1 => 5
 
+LetNameStartingWithDash
+  globals [glob1]
+  O> let -WOLF-SHAPE-00013 5 set glob1 -WOLF-SHAPE-00013
+  glob1 => 5
+
 LetWithAsk
   turtles-own [tvar]
   O> crt 5

--- a/parser-core/src/main/lex/TokenLexer.scala
+++ b/parser-core/src/main/lex/TokenLexer.scala
@@ -31,7 +31,7 @@ class TokenLexer {
       val r = Seq(extensionLiteral, punct, comment, numericLiteral, string, ident, illegalCharacter)
         .foldLeft((Option.empty[Token], input)) {
         case ((Some(token), remaining), (prefixDetector, tokenizer)) => (Some(token), remaining)
-        case ((None, remaining), (prefixDetector, tokenizer)) =>
+        case ((None,        remaining), (prefixDetector, tokenizer)) =>
           remaining.assembleToken(prefixDetector, tokenizer)
             .map(o => (Some(o._1), o._2))
             .getOrElse((None, remaining))
@@ -93,7 +93,9 @@ class TokenLexer {
 
   def numericLiteral: (LexPredicate, TokenGenerator) =
     (chain(
-      characterMatching(c => Character.isDigit(c) || c == '.' || c == '-'),
+      anyOf(characterMatching(Character.isDigit),
+        chain(anyOf('.', '-'),
+          anyOf(characterMatching(Character.isDigit), chain('.', characterMatching(Character.isDigit))))),
       zeroOrMore(c => validIdentifierChar(c))),
       tokenizeLiteral)
 

--- a/parser-jvm/src/test/lex/TokenizerTests.scala
+++ b/parser-jvm/src/test/lex/TokenizerTests.scala
@@ -102,6 +102,7 @@ class TokenizerTests extends FunSuite {
     assertResult("Illegal number format")(
       firstBadToken(tokens).get.value)
   }
+
   test("TokenizeBadNumberFormat2") {
     val tokens = tokenizeRobustly("__ignore 3__ignore 4")
     assertResult(9)(firstBadToken(tokens).get.start)
@@ -109,6 +110,13 @@ class TokenizerTests extends FunSuite {
     assertResult("Illegal number format")(
       firstBadToken(tokens).get.value)
   }
+
+  test("TokenizeIdentStartingWithDash") {
+    val tokens   = tokenizeRobustly("-WOLF-SHAPE-00013")
+    val expected = "Token(-WOLF-SHAPE-00013,Ident,-WOLF-SHAPE-00013)"
+    assertResult(expected)(tokens.mkString)
+  }
+
   test("TokenizeLooksLikePotentialNumber") {
     val tokens = tokenize("-.")
     val expected = "Token(-.,Ident,-.)"


### PR DESCRIPTION
Try this language test to reproduce the issue:

> LetNameStartingWithDash
      O> let -WOLF-SHAPE-00013 5

You will get this:

> [info]   org.nlogo.core.CompilerException: Illegal number format
[info]   at org.nlogo.parse.Namer0$.apply(Namer0.scala:11)
[info]   at org.nlogo.parse.Namer0$.apply(Namer0.scala:8)
[info]   at scala.collection.Iterator$$anon$11.next(Iterator.scala:370)
[info]   at scala.collection.Iterator$class.toStream(Iterator.scala:1188)
[info]   at scala.collection.AbstractIterator.toStream(Iterator.scala:1202)
[info]   at scala.collection.Iterator$$anonfun$toStream$1.apply(Iterator.scala:1188)
[info]   at scala.collection.Iterator$$anonfun$toStream$1.apply(Iterator.scala:1188)
[info]   at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1222)
[info]   at scala.collection.immutable.Stream$Cons.tail(Stream.scala:1212)
[info]   at org.nlogo.parse.SeqReader.rest(StructureCombinators.scala:194)

This is breaking the latest version of the parser, and prevents me from publishing my fix for NetLogo/Tortoise#141