### PR TITLE
Compiler gets angry about files saved in NetLogo 5.2.0

### DIFF
--- a/bin/shell.sh
+++ b/bin/shell.sh
@@ -7,4 +7,4 @@ fi
 rlwrap ./sbt \
   -Djline.terminal=jline.UnsupportedTerminal \
   --warn \
-  "run-main org.nlogo.headless.Shell $ARG"
+  "jvmBuild/runMain org.nlogo.headless.Shell $ARG"

--- a/build.sbt
+++ b/build.sbt
@@ -151,6 +151,7 @@ lazy val jvmBuild = (project in file ("jvm")).
     version := "5.2.0",
     isSnapshot := true,
     libraryDependencies += "org.ow2.asm" % "asm-all" % "5.0.4",
+    (fullClasspath in Runtime) ++= (fullClasspath in Runtime in parserJVM).value,
     mainClass in Compile := Some("org.nlogo.headless.Main"),
     onLoadMessage := "",
     name := "NetLogoHeadless",

--- a/shared/resources/main/system/version.txt
+++ b/shared/resources/main/system/version.txt
@@ -1,5 +1,6 @@
-NetLogo 5.2.0-M1
+NetLogo 5.2.0
 INTERIM DEVEL BUILD
+NetLogo 5.2.0-M1
 NetLogo 5.1
 NetLogo 5.0
 NetLogo 4.


### PR DESCRIPTION
  1. Save a model file from NetLogo 5.2
  2. Try to open it in Headless
  3. You will get this:

> [info]   java.lang.IllegalStateException: unknown NetLogo version: NetLogo 5.2.0
[info]   at org.nlogo.headless.HeadlessModelOpener.openFromModel(HeadlessModelOpener.scala:35)
[info]   at org.nlogo.headless.HeadlessWorkspace.openModel(HeadlessWorkspace.scala:389)
[info]   at org.nlogo.headless.HeadlessWorkspace.open(HeadlessWorkspace.scala:371)
[info]   at org.nlogo.headless.Main$.org$nlogo$headless$Main$$newWorkspace$1(Main.scala:22)
[info]   at org.nlogo.headless.Main$.runExperiment(Main.scala:26)
[info]   at org.nlogo.headless.Main$$anonfun$main$1.apply(Main.scala:16)
[info]   at org.nlogo.headless.Main$$anonfun$main$1.apply(Main.scala:16)
[info]   at scala.Option.foreach(Option.scala:257)
[info]   at org.nlogo.headless.Main$.main(Main.scala:16)
[info]   at org.nlogo.headless.misc.TestMain$$anonfun$3$$anonfun$4.apply$mcV$sp(TestMain.scala:34)