### PR TITLE
upgrade to ScalaCheck 1.12.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val testSettings = scalatestSettings ++ Seq(
     "org.jmock" % "jmock" % "2.8.1" % "test",
     "org.jmock" % "jmock-legacy" % "2.8.1" % "test",
     "org.jmock" % "jmock-junit4" % "2.8.1" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.12.2" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.12.4" % "test",
     "org.reflections" % "reflections" % "0.9.10" % "test",
     "org.slf4j" % "slf4j-nop" % "1.7.12" % "test"
   )


### PR DESCRIPTION
no special reason, just keeping current

we skipped 1.12.3 because it was broken