### PR TITLE
upgrade to Scala 2.11.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 jdk: oraclejdk8
 language: scala
-scala: 2.11.6
+scala: 2.11.7
 before_install:
   - git submodule update --init --recursive
 install:

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val commonSettings = Seq(
   ivyLoggingLevel := UpdateLogging.Quiet,
   logBuffered in testOnly in Test := false,
   onLoadMessage := "",
-  scalaVersion := "2.11.6",
+  scalaVersion := "2.11.7",
   // don't cross-build for different Scala versions
   crossPaths := false
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -26,7 +26,7 @@ resolvers += Resolver.url(
     url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
         Resolver.ivyStylePatterns)
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.2")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.4")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.2")
 


### PR DESCRIPTION
Scala 2.11.7 has been published to Maven Central, but hasn't yet
been announced.  it's still possible some last-minute regression
will be discovered, so even if this passes Travis, you might
wait to merge this until the release has actually been announced