### PR TITLE
Add "disable until ticks start" to button object.

### DIFF
--- a/parser-core/src/main/core/Widget.scala
+++ b/parser-core/src/main/core/Widget.scala
@@ -28,8 +28,8 @@ sealed trait DeclaresGlobalCommand {
   def command: String = "set " + varName + " " + asNetLogoString(default)
 }
 case class Button(display: Option[String], left: Int, top: Int, right: Int, bottom: Int,
-             source: String, forever: Boolean, disableUntilTicksStart: Boolean,
-             buttonType: String = "OBSERVER", actionKey: String = "NIL") extends Widget
+             source: String, forever: Boolean, buttonType: String = "OBSERVER",
+             actionKey: String = "NIL", disableUntilTicksStart: Boolean = false) extends Widget
 
 case class Plot(display: String, left: Int = 0, top: Int = 0, right: Int = 5, bottom: Int = 5,
              xAxis: String = "", yAxis: String = "", xmin: Double = 0, xmax: Double = 0, ymin: Double = 0, ymax: Double = 0,

--- a/parser-core/src/main/core/Widget.scala
+++ b/parser-core/src/main/core/Widget.scala
@@ -28,7 +28,8 @@ sealed trait DeclaresGlobalCommand {
   def command: String = "set " + varName + " " + asNetLogoString(default)
 }
 case class Button(display: Option[String], left: Int, top: Int, right: Int, bottom: Int,
-             source: String, forever: Boolean, buttonType: String = "OBSERVER", actionKey: String = "NIL") extends Widget
+             source: String, forever: Boolean, disableUntilTicksStart: Boolean,
+             buttonType: String = "OBSERVER", actionKey: String = "NIL") extends Widget
 
 case class Plot(display: String, left: Int = 0, top: Int = 0, right: Int = 5, bottom: Int = 5,
              xAxis: String = "", yAxis: String = "", xmin: Double = 0, xmax: Double = 0, ymin: Double = 0, ymax: Double = 0,

--- a/parser-core/src/main/core/model/WidgetReader.scala
+++ b/parser-core/src/main/core/model/WidgetReader.scala
@@ -177,14 +177,16 @@ object ButtonReader extends BaseWidgetReader {
                         StringLine(),  // actionkey
                         ReservedLine(),
                         ReservedLine(),
-                        BooleanLine(Some(true))  // go time
+                        IntLine()  // Enabled before ticks start implemented as an int
                       )
   def asList(button: Button) = List((), button.left, button.top, button.right, button.bottom, button.display,
-                                    button.source, button.forever, (), (), button.buttonType, (), button.actionKey, (), (), true)
+                                    button.source, button.forever, (), (), button.buttonType, (), button.actionKey,
+                                    (), (), if(button.disableUntilTicksStart) 0 else 1)
   def asWidget(vals: List[Any]): Button = {
     val List(_, left: Int, top: Int, right: Int, bottom: Int, rawDisplay: Option[String] @unchecked,
-      source: String, forever: Boolean, _, _, buttonType: String, _, actionKey: String, _, _, _) = vals
-    Button(rawDisplay, left, top, right, bottom, source, forever, buttonType, actionKey)
+      source: String, forever: Boolean, _, _, buttonType: String, _, actionKey: String, _, _,
+      enabledBeforeTicks: Int) = vals
+    Button(rawDisplay, left, top, right, bottom, source, forever, enabledBeforeTicks == 0, buttonType, actionKey)
   }
 }
 

--- a/parser-core/src/main/core/model/WidgetReader.scala
+++ b/parser-core/src/main/core/model/WidgetReader.scala
@@ -186,7 +186,7 @@ object ButtonReader extends BaseWidgetReader {
     val List(_, left: Int, top: Int, right: Int, bottom: Int, rawDisplay: Option[String] @unchecked,
       source: String, forever: Boolean, _, _, buttonType: String, _, actionKey: String, _, _,
       enabledBeforeTicks: Int) = vals
-    Button(rawDisplay, left, top, right, bottom, source, forever, enabledBeforeTicks == 0, buttonType, actionKey)
+    Button(rawDisplay, left, top, right, bottom, source, forever, buttonType, actionKey, enabledBeforeTicks == 0)
   }
 }
 

--- a/parser-jvm/src/test/core/model/WidgetTest.scala
+++ b/parser-jvm/src/test/core/model/WidgetTest.scala
@@ -110,9 +110,9 @@ class WidgetTest extends FunSuite {
                     |NIL
                     |1""".stripMargin.split("\n").toList
     assert(ButtonReader.validate(button))
-    assert(Button(Some("go"),202,101,271,134,"go",true,false) == ButtonReader.parse(button))
+    assert(Button(Some("go"),202,101,271,134,"go",true) == ButtonReader.parse(button))
     assert(ButtonReader.validate(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
-    assert(Button(Some("go"),202,101,271,134,"go",true,false) ==
+    assert(Button(Some("go"),202,101,271,134,"go",true) ==
       ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
   }
 
@@ -134,9 +134,9 @@ class WidgetTest extends FunSuite {
                     |NIL
                     |1""".stripMargin.split("\n").toList
     assert(ButtonReader.validate(button))
-    assert(Button(None,202,101,271,134,"go",true,false) == ButtonReader.parse(button))
+    assert(Button(None,202,101,271,134,"go",true) == ButtonReader.parse(button))
     assert(ButtonReader.validate(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
-    assert(Button(None,202,101,271,134,"go",true,false) ==
+    assert(Button(None,202,101,271,134,"go",true) ==
       ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
     assert(None == ButtonReader.parse(button).display)
   }
@@ -159,9 +159,9 @@ class WidgetTest extends FunSuite {
                     |NIL
                     |1""".stripMargin.split("\n").toList
     assert(ButtonReader.validate(button))
-    assert(Button(None,202,101,271,134,"\"bar\"",true,false) == ButtonReader.parse(button))
+    assert(Button(None,202,101,271,134,"\"bar\"",true) == ButtonReader.parse(button))
     assert(ButtonReader.validate(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
-    assert(Button(None,202,101,271,134,"\"bar\"",true,false) ==
+    assert(Button(None,202,101,271,134,"\"bar\"",true) ==
       ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
     assert(None == ButtonReader.parse(button).display)
   }
@@ -184,9 +184,9 @@ class WidgetTest extends FunSuite {
                     |NIL
                     |0""".stripMargin.split("\n").toList
     assert(ButtonReader.validate(button))
-    assert(Button(None,202,101,271,134,"\"bar\"",true,true) == ButtonReader.parse(button))
+    assert(Button(None,202,101,271,134,"\"bar\"",true,disableUntilTicksStart = true) == ButtonReader.parse(button))
     assert(ButtonReader.validate(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
-    assert(Button(None,202,101,271,134,"\"bar\"",true,true) ==
+    assert(Button(None,202,101,271,134,"\"bar\"",true,disableUntilTicksStart = true) ==
       ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
     assert(None == ButtonReader.parse(button).display)
   }

--- a/parser-jvm/src/test/core/model/WidgetTest.scala
+++ b/parser-jvm/src/test/core/model/WidgetTest.scala
@@ -110,9 +110,9 @@ class WidgetTest extends FunSuite {
                     |NIL
                     |1""".stripMargin.split("\n").toList
     assert(ButtonReader.validate(button))
-    assert(Button(Some("go"),202,101,271,134,"go",true) == ButtonReader.parse(button))
+    assert(Button(Some("go"),202,101,271,134,"go",true,false) == ButtonReader.parse(button))
     assert(ButtonReader.validate(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
-    assert(Button(Some("go"),202,101,271,134,"go",true) ==
+    assert(Button(Some("go"),202,101,271,134,"go",true,false) ==
       ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
   }
 
@@ -134,9 +134,9 @@ class WidgetTest extends FunSuite {
                     |NIL
                     |1""".stripMargin.split("\n").toList
     assert(ButtonReader.validate(button))
-    assert(Button(None,202,101,271,134,"go",true) == ButtonReader.parse(button))
+    assert(Button(None,202,101,271,134,"go",true,false) == ButtonReader.parse(button))
     assert(ButtonReader.validate(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
-    assert(Button(None,202,101,271,134,"go",true) ==
+    assert(Button(None,202,101,271,134,"go",true,false) ==
       ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
     assert(None == ButtonReader.parse(button).display)
   }
@@ -159,9 +159,34 @@ class WidgetTest extends FunSuite {
                     |NIL
                     |1""".stripMargin.split("\n").toList
     assert(ButtonReader.validate(button))
-    assert(Button(None,202,101,271,134,"\"bar\"",true) == ButtonReader.parse(button))
+    assert(Button(None,202,101,271,134,"\"bar\"",true,false) == ButtonReader.parse(button))
     assert(ButtonReader.validate(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
-    assert(Button(None,202,101,271,134,"\"bar\"",true) ==
+    assert(Button(None,202,101,271,134,"\"bar\"",true,false) ==
+      ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
+    assert(None == ButtonReader.parse(button).display)
+  }
+
+  test("button disabled until ticks start") {
+    val button = """|BUTTON
+                    |202
+                    |101
+                    |271
+                    |134
+                    |NIL
+                    |\"bar\"
+                    |T
+                    |1
+                    |T
+                    |OBSERVER
+                    |NIL
+                    |NIL
+                    |NIL
+                    |NIL
+                    |0""".stripMargin.split("\n").toList
+    assert(ButtonReader.validate(button))
+    assert(Button(None,202,101,271,134,"\"bar\"",true,true) == ButtonReader.parse(button))
+    assert(ButtonReader.validate(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
+    assert(Button(None,202,101,271,134,"\"bar\"",true,true) ==
       ButtonReader.parse(ButtonReader.format(ButtonReader.parse(button)).split("\n").toList))
     assert(None == ButtonReader.parse(button).display)
   }
@@ -326,14 +351,14 @@ class WidgetTest extends FunSuite {
                   |"grass / 4" 1.0 0 -10899396 true "" ";; divide by four to keep it within similar\n;; range as wolf and sheep populations\nplot count patches with [ pcolor = green ] / 4" """.stripMargin.split("\n").toList
     assert(PlotReader.validate(plot))
     assert(Plot("populations", 33, 265, 369, 408, "time", "pop.", 0.0, 100.0, 0.0, 100.0, true, true, "", "",
-      List(Pen("sheep", 1.0, 0, -13345367, true, "", "plot count sheep"), 
-           Pen("wolves", 1.0, 0, -2674135, true, "", "plot count wolves"), 
+      List(Pen("sheep", 1.0, 0, -13345367, true, "", "plot count sheep"),
+           Pen("wolves", 1.0, 0, -2674135, true, "", "plot count wolves"),
            Pen("grass / 4", 1.0, 0, -10899396, true, "", ";; divide by four to keep it within similar\n;; range as wolf and sheep populations\nplot count patches with [ pcolor = green ] / 4"))) ==
          PlotReader.parse(plot))
     assert(PlotReader.validate(PlotReader.format(PlotReader.parse(plot)).split("\n").toList))
     assert(Plot("populations", 33, 265, 369, 408, "time", "pop.", 0.0, 100.0, 0.0, 100.0, true, true, "", "",
-      List(Pen("sheep", 1.0, 0, -13345367, true, "", "plot count sheep"), 
-           Pen("wolves", 1.0, 0, -2674135, true, "", "plot count wolves"), 
+      List(Pen("sheep", 1.0, 0, -13345367, true, "", "plot count sheep"),
+           Pen("wolves", 1.0, 0, -2674135, true, "", "plot count wolves"),
            Pen("grass / 4", 1.0, 0, -10899396, true, "", ";; divide by four to keep it within similar\n;; range as wolf and sheep populations\nplot count patches with [ pcolor = green ] / 4"))) ==
       PlotReader.parse(PlotReader.format(PlotReader.parse(plot)).split("\n").toList))
   }


### PR DESCRIPTION
Fixes #49 

Code is a little uglier than other parsing code since there's a type and parity mismatch between the notion of "disable until ticks start" and what's serialized in the nlogo file.