### PR TITLE
Wip model uses core shapes

### DIFF
--- a/jvm/src/main/headless/HeadlessModelOpener.scala
+++ b/jvm/src/main/headless/HeadlessModelOpener.scala
@@ -6,9 +6,10 @@ import workspace.WorldLoader
 import org.nlogo.plot.PlotLoader
 import org.nlogo.agent.{BooleanConstraint, ChooserConstraint, InputBoxConstraint, NumericConstraint}
 import org.nlogo.api.{ValueConstraint, Version}
-import org.nlogo.core.{model, ShapeParser, CompilerException, Program, ConstraintSpecification, LogoList, Model},
+import org.nlogo.core.{model, Shape, ShapeParser, CompilerException, Program, ConstraintSpecification, LogoList, Model},
   model.ModelReader,
-  ConstraintSpecification._
+  ConstraintSpecification._,
+  Shape.{ LinkShape => CoreLinkShape, VectorShape => CoreVectorShape }
 
 import org.nlogo.shape.{ShapeConverter, LinkShape, VectorShape}
 
@@ -59,8 +60,8 @@ class HeadlessModelOpener(ws: HeadlessWorkspace) {
     if (!previewCommands.trim.isEmpty) ws.previewCommands = previewCommands
 
     // parse turtle and link shapes, updating the workspace.
-    parseShapes(model.turtleShapes.toArray,
-                model.linkShapes.toArray,
+    parseShapes(model.turtleShapes,
+                model.linkShapes,
                 netLogoVersion)
 
     ws.init()
@@ -74,15 +75,15 @@ class HeadlessModelOpener(ws: HeadlessWorkspace) {
   }
 
 
-  private def parseShapes(turtleShapeLines: Array[String], linkShapeLines: Array[String], netLogoVersion: String) {
+  private def parseShapes(turtleShapes: List[CoreVectorShape], linkShapes: List[CoreLinkShape], netLogoVersion: String) {
     ws.world.turtleShapeList.replaceShapes(
-      ShapeParser.parseVectorShapes(turtleShapeLines).map(ShapeConverter.baseVectorShapeToVectorShape))
-    if (turtleShapeLines.isEmpty) ws.world.turtleShapeList.add(VectorShape.getDefaultShape)
+      turtleShapes.map(ShapeConverter.baseVectorShapeToVectorShape))
+    if (turtleShapes.isEmpty) ws.world.turtleShapeList.add(VectorShape.getDefaultShape)
 
     // A new model is being loaded, so get rid of all previous shapes
     ws.world.linkShapeList.replaceShapes(
-      ShapeParser.parseLinkShapes(linkShapeLines).map(ShapeConverter.baseLinkShapeToLinkShape))
-    if (linkShapeLines.isEmpty) ws.world.linkShapeList.add(LinkShape.getDefaultLinkShape)
+      linkShapes.map(ShapeConverter.baseLinkShapeToLinkShape))
+    if (linkShapes.isEmpty) ws.world.linkShapeList.add(LinkShape.getDefaultLinkShape)
   }
 
   private def finish(constraints: Map[String, ConstraintSpecification], program: Program, interfaceGlobalCommands: String) {

--- a/jvm/src/test/headless/render/TestUsingWorkspace.scala
+++ b/jvm/src/test/headless/render/TestUsingWorkspace.scala
@@ -45,9 +45,9 @@ trait TestUsingWorkspace extends MockSuite {
       workspace.openModel(Model(widgets = List(View.square(radius))))
       workspace.changeTopology(worldType.xWrap, worldType.yWrap)
       workspace.world.turtleShapeList.replaceShapes(
-        ShapeParser.parseVectorShapes(Model.defaultShapes).map(ShapeConverter.baseVectorShapeToVectorShape))
+        Model.defaultShapes.map(ShapeConverter.baseVectorShapeToVectorShape))
       workspace.world.linkShapeList.replaceShapes(
-        ShapeParser.parseLinkShapes(Model.defaultLinkShapes).map(ShapeConverter.baseLinkShapeToLinkShape))
+        Model.defaultLinkShapes.map(ShapeConverter.baseLinkShapeToLinkShape))
       f(workspace)
     }
     finally workspace.dispose()

--- a/parser-core/src/main/core/Model.scala
+++ b/parser-core/src/main/core/Model.scala
@@ -2,9 +2,13 @@
 
 package org.nlogo.core
 
+import Shape.{ VectorShape, LinkShape }
+
+import ShapeParser.{ parseVectorShapes, parseLinkShapes }
+
 case class Model(code: String = "", widgets: List[Widget] = List(View()), info: String = "", version: String = "NetLogo 5.0",
-  turtleShapes: List[String] = Model.defaultShapes, behaviorSpace: List[String] = Nil,
-  linkShapes: List[String] = Model.defaultLinkShapes, previewCommands: List[String] = Nil) {
+  turtleShapes: List[VectorShape] = Model.defaultShapes, behaviorSpace: List[String] = Nil,
+  linkShapes: List[LinkShape] = Model.defaultLinkShapes, previewCommands: List[String] = Nil) {
 
   def interfaceGlobals: List[String] = widgets.collect{case x:DeclaresGlobal => x}.map(_.varName)
   def constraints: Map[String, ConstraintSpecification] = widgets.collect{case x:DeclaresConstraint => (x.varName, x.constraint)}.toMap
@@ -19,8 +23,8 @@ case class Model(code: String = "", widgets: List[Widget] = List(View()), info: 
 }
 
 object Model {
-  lazy val defaultShapes: List[String] =
-    Resource.lines("/system/defaultShapes.txt").toList
-  lazy val defaultLinkShapes: List[String] =
-    Resource.lines("/system/defaultLinkShapes.txt").toList
+  lazy val defaultShapes: List[VectorShape] =
+    parseVectorShapes(Resource.lines("/system/defaultShapes.txt").toSeq).toList
+  lazy val defaultLinkShapes: List[LinkShape] =
+    parseLinkShapes(Resource.lines("/system/defaultLinkShapes.txt").toSeq).toList
 }

--- a/parser-core/src/main/core/model/ModelReader.scala
+++ b/parser-core/src/main/core/model/ModelReader.scala
@@ -41,13 +41,13 @@ object ModelReader {
     model.code + s"\n$SEPARATOR\n" +
       WidgetReader.formatInterface(model.widgets, parser) + s"\n$SEPARATOR\n" +
       model.info + s"\n$SEPARATOR\n" +
-      model.turtleShapes.mkString("\n") + s"\n$SEPARATOR\n" +
+      ShapeParser.formatVectorShapes(model.turtleShapes) + s"\n$SEPARATOR\n" +
       model.version + s"\n$SEPARATOR" +
       (if(model.previewCommands.nonEmpty) model.previewCommands.mkString("\n", "\n", "\n") else "\n") + s"$SEPARATOR\n" +
       s"$SEPARATOR" +
       (if(model.behaviorSpace.nonEmpty) model.behaviorSpace.mkString("\n", "\n", "\n") else "\n") + s"$SEPARATOR\n" +
       s"$SEPARATOR\n" +
-      model.linkShapes.mkString("\n") + s"\n$SEPARATOR\n" +
+      ShapeParser.formatLinkShapes(model.linkShapes) + s"\n$SEPARATOR\n" +
       s"$SEPARATOR\n"
   }
 }

--- a/parser-core/src/main/core/model/ModelReader.scala
+++ b/parser-core/src/main/core/model/ModelReader.scala
@@ -2,7 +2,7 @@
 
 package org.nlogo.core.model
 
-import org.nlogo.core.{LiteralParser, Model}
+import org.nlogo.core.{ LiteralParser, Model, ShapeParser }
 
 object ModelReader {
 
@@ -28,8 +28,10 @@ object ModelReader {
       throw new RuntimeException(
         "Models must have 12 sections, this had " + sections.size)
 
-    val Vector(code, interface, info, turtleShapes, version, previewCommands, systemDynamics,
-             behaviorSpace, hubNetClient, linkShapes, modelSettings, deltaTick) = sections
+    val Vector(code, interface, info, turtleShapeLines, version, previewCommands, systemDynamics,
+             behaviorSpace, hubNetClient, linkShapeLines, modelSettings, deltaTick) = sections
+    val turtleShapes = ShapeParser.parseVectorShapes(turtleShapeLines)
+    val linkShapes   = ShapeParser.parseLinkShapes(linkShapeLines)
     new Model(code.mkString("\n"), WidgetReader.readInterface(interface.toList, parser),
               info.mkString("\n"), version.head, turtleShapes.toList, behaviorSpace.toList,
               linkShapes.toList, previewCommands.toList)


### PR DESCRIPTION
This is needed to [preserve custom shapes in Galapagos](https://github.com/NetLogo/Galapagos/issues/237). A quick once-over by @qiemem or @TheBizzle would be great, if you have time, but there aren't a ton of big changes here, mostly just having models hold shape objects instead of an array of shape strings from the model.