### PR TITLE
Check that stop is not used in reporters 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,10 @@ lazy val scalatestSettings = Seq(
   // show test failures again at end, after all tests complete.
   // T gives truncated stack traces; change to G if you need full.
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oT"),
-  libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test"
+  libraryDependencies ++= Seq(
+    "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+    "org.scalacheck" %% "scalacheck" % "1.12.4" % "test"
+  )
 )
 
 lazy val testSettings = scalatestSettings ++ Seq(
@@ -43,7 +46,6 @@ lazy val testSettings = scalatestSettings ++ Seq(
     "org.jmock" % "jmock" % "2.8.1" % "test",
     "org.jmock" % "jmock-legacy" % "2.8.1" % "test",
     "org.jmock" % "jmock-junit4" % "2.8.1" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.12.4" % "test",
     "org.reflections" % "reflections" % "0.9.10" % "test",
     "org.slf4j" % "slf4j-nop" % "1.7.12" % "test"
   )

--- a/jvm/resources/test/commands/Stop.txt
+++ b/jvm/resources/test/commands/Stop.txt
@@ -44,6 +44,10 @@ StopFromNestedForeachInsideReporterProcedure
   to-report foo foreach [1 2] [ foreach [3 4] [ stop ] ] end
   COMPILE> COMPILER ERROR STOP is not allowed inside TO-REPORT.
 
+ReportFromForeachInsideProcedure
+  to foo foreach [1 2 3] [ report ? ] end
+  COMPILE> COMPILER ERROR REPORT can only be used inside TO-REPORT.
+
 StopTask1
   globals [glob1 glob2]
   O> set glob1 task [ stop ]

--- a/jvm/resources/test/commands/Stop.txt
+++ b/jvm/resources/test/commands/Stop.txt
@@ -44,6 +44,10 @@ StopFromNestedForeachInsideReporterProcedure
   to-report foo foreach [1 2] [ foreach [3 4] [ stop ] ] end
   COMPILE> COMPILER ERROR STOP is not allowed inside TO-REPORT.
 
+ReportFromNestedAsk
+  to-report foo ask turtles [ report who ] end
+  COMPILE> COMPILER ERROR REPORT must be immediately inside a TO-REPORT.
+
 ReportFromForeachInsideProcedure
   to foo foreach [1 2 3] [ report ? ] end
   COMPILE> COMPILER ERROR REPORT can only be used inside TO-REPORT.

--- a/jvm/resources/test/commands/Stop.txt
+++ b/jvm/resources/test/commands/Stop.txt
@@ -38,11 +38,11 @@ StopFromForeach3
 
 StopFromForeachInsideReporterProcedure
   to-report foo foreach [1 2 3] [ stop ] end
-  O> __ignore foo => ERROR STOP is not allowed inside TO-REPORT.
+  COMPILE> COMPILER ERROR STOP is not allowed inside TO-REPORT.
 
 StopFromNestedForeachInsideReporterProcedure
   to-report foo foreach [1 2] [ foreach [3 4] [ stop ] ] end
-  O> __ignore foo => ERROR STOP is not allowed inside TO-REPORT.
+  COMPILE> COMPILER ERROR STOP is not allowed inside TO-REPORT.
 
 StopTask1
   globals [glob1 glob2]

--- a/jvm/resources/test/commands/WithLocalRandomness.txt
+++ b/jvm/resources/test/commands/WithLocalRandomness.txt
@@ -51,7 +51,6 @@ WithLocalRandomnessCarefully
   glob1 = [who] of turtles => true
 
 WithLocalRandomnessReport
-  globals [glob1]
+  globals [ glob1 ]
   to-report foo with-local-randomness [ report [who] of turtles set glob1 [who] of turtles ] end
-  O> crt 4
-  O> set glob1 foo => ERROR REPORT must be immediately inside a TO-REPORT.
+  COMPILE> COMPILER ERROR REPORT must be immediately inside a TO-REPORT.

--- a/jvm/src/test/headless/lang/Fixture.scala
+++ b/jvm/src/test/headless/lang/Fixture.scala
@@ -9,7 +9,8 @@ import org.nlogo.core.{CompilerException, Femto, Model, View}
 import CompilerException.{RuntimeErrorAtCompileTimePrefix => runtimePrefix}
 import org.nlogo.nvm.CompilerInterface
 import org.nlogo.headless.test.{RunMode, NormalMode, TestMode, CompileError,
-                                Success, Result, Reporter, Command, AbstractFixture, RuntimeError, StackTrace}
+                                Success, Result, Reporter, Command, Compile,
+                                AbstractFixture, RuntimeError, StackTrace}
 
 trait FixtureSuite extends scalatest.fixture.FunSuite {
   type FixtureParam = Fixture
@@ -112,6 +113,13 @@ class Fixture(name: String) extends AbstractFixture {
     catch catcher(s"command: $command", command.result)
   }
 
+  override def checkCompile(model: Model, compile: Compile) =
+    try {
+      open(model)
+      if (compile.result.isInstanceOf[CompileError])
+        fail("no CompilerException occurred")
+    } catch catcher(s"compile: ${model.code}", compile.result)
+
   // ConstantFolder makes this complicated, by turning some runtime errors into
   // compile-time errors.  Furthermore in RunMode the compile-time error again
   // becomes a runtime error, but with "Runtime error: " tacked onto the front.
@@ -145,5 +153,4 @@ class Fixture(name: String) extends AbstractFixture {
     workspace.open(path)
   def open(model: Model) =
     workspace.openModel(model)
-
 }

--- a/jvm/src/test/headless/test/AbstractFixture.scala
+++ b/jvm/src/test/headless/test/AbstractFixture.scala
@@ -15,6 +15,7 @@ trait AbstractFixture {
   def declare(model: Model = Model(widgets = List(defaultView)))
   def open(path: String)
   def open(model: Model)
+  def checkCompile(model: Model, compile: Compile)
   def runCommand(command: Command, mode: TestMode)
   def runReporter(reporter: Reporter, mode: TestMode)
   def readFromString(literal: String): AnyRef

--- a/jvm/src/test/headless/test/Finder.scala
+++ b/jvm/src/test/headless/test/Finder.scala
@@ -94,7 +94,7 @@ trait Finder extends FunSuite with SlowTest {
             .mkString("\n").trim
 
         // you can't use declarations and opens in the same model
-        assert(t.entries.exists(_.isInstanceOf[Declaration]) && t.entries.exists(_.isInstanceOf[Open]))
+        assert(! (t.entries.exists(_.isInstanceOf[Declaration]) && t.entries.exists(_.isInstanceOf[Open])))
 
         if (! nonDecls.exists(e => e.isInstanceOf[Compile] || e.isInstanceOf[Open]))
           fixture.open(new Model(

--- a/jvm/src/test/headless/test/LanguageTest.scala
+++ b/jvm/src/test/headless/test/LanguageTest.scala
@@ -19,6 +19,7 @@ case class Declaration(source: String)                                extends En
 case class Command(command: String,
   kind: AgentKind = AgentKind.Observer, result: Result = Success("")) extends Entry
 case class Reporter(reporter: String, result: Result)                 extends Entry
+case class Compile(result: Result)                                    extends Entry
 
 sealed trait Result
 case class Success       (message: String) extends Result

--- a/parser-core/src/main/core/AstNode.scala
+++ b/parser-core/src/main/core/AstNode.scala
@@ -71,8 +71,10 @@ class ProcedureDefinition(val procedure: FrontEndProcedure, val statements: Stat
   def end = throw new UnsupportedOperationException
   def file = throw new UnsupportedOperationException
 
-  def copy(procedure: FrontEndProcedure = procedure,
-            statements: Statements = statements): ProcedureDefinition = {
+  def nonLocalExit = statements.nonLocalExit
+
+  def copy(procedure:  FrontEndProcedure = procedure,
+           statements: Statements        = statements): ProcedureDefinition = {
     new ProcedureDefinition(procedure, statements)
   }
 }
@@ -82,13 +84,17 @@ class ProcedureDefinition(val procedure: FrontEndProcedure, val statements: Stat
  * not necessarily a "block" of statements, as block means something specific
  * (enclosed in [], in particular). This class is used to represent other
  * groups of statements as well, for instance procedure bodies.
+ * nonLocalExit identifies that the statements contain one or more commands
+ * (possibly nested) which may cause a non-local exit (like `stop` or `report`)
  */
-class Statements(val file: String) extends AstNode {
-  def this(file: String, stmts: Seq[Statement]) = {
-    this(file)
+class Statements(val file: String, val nonLocalExit: Boolean) extends AstNode {
+  def this(file: String, stmts: Seq[Statement], nonLocalExit: Boolean) = {
+    this(file, nonLocalExit)
     _stmts.appendAll(stmts)
     recomputeStartAndEnd()
   }
+
+  def this(file: String) = { this(file, Seq(), false) }
 
   var start: Int = _
   var end: Int = _
@@ -107,8 +113,8 @@ class Statements(val file: String) extends AstNode {
   }
   override def toString = stmts.mkString(" ")
 
-  def copy(file: String = file, stmts: Seq[Statement] = stmts): Statements = {
-    new Statements(file, stmts)
+  def copy(file: String = file, stmts: Seq[Statement] = stmts, nonLocalExit: Boolean = nonLocalExit): Statements = {
+    new Statements(file, stmts, nonLocalExit)
   }
 }
 

--- a/parser-core/src/main/core/Syntax.scala
+++ b/parser-core/src/main/core/Syntax.scala
@@ -45,7 +45,8 @@ case class Syntax private(
   minimumOption: Option[Int], // minimum number of args might be different than the default
   isRightAssociative: Boolean, // only relevant if infix
   agentClassString: String,
-  blockAgentClassString: Option[String])
+  blockAgentClassString: Option[String],
+  introducesContext: Boolean)
 {
 
   import Syntax._
@@ -135,7 +136,8 @@ object Syntax {
     defaultOption: Option[Int] = None,
     minimumOption: Option[Int] = None, // minimum number of args might be different than the default
     agentClassString: String = "OTPL",
-    blockAgentClassString: Option[String] = None
+    blockAgentClassString: Option[String] = None,
+    introducesContext: Boolean = false
   ) = new Syntax(
     precedence = CommandPrecedence,
     left = Syntax.VoidType,
@@ -145,7 +147,8 @@ object Syntax {
     minimumOption = minimumOption,
     isRightAssociative = false,
     agentClassString = agentClassString,
-    blockAgentClassString = blockAgentClassString
+    blockAgentClassString = blockAgentClassString,
+    introducesContext = introducesContext || blockAgentClassString.nonEmpty
   )
 
   def reporterSyntax(
@@ -167,7 +170,8 @@ object Syntax {
     minimumOption = minimumOption,
     isRightAssociative = isRightAssociative,
     agentClassString = agentClassString,
-    blockAgentClassString = blockAgentClassString
+    blockAgentClassString = blockAgentClassString,
+    introducesContext = blockAgentClassString.nonEmpty
   )
 
   /** <i>Unsupported. Do not use.</i> */

--- a/parser-core/src/main/core/prim/etc/java.scala
+++ b/parser-core/src/main/core/prim/etc/java.scala
@@ -578,7 +578,8 @@ case class _while() extends Command {
 case class _withlocalrandomness() extends Command {
   override def syntax =
     Syntax.commandSyntax(
-      right = List(Syntax.CommandBlockType))
+      right = List(Syntax.CommandBlockType),
+      introducesContext = true)
 }
 case class _withmax() extends Reporter {
   override def syntax =
@@ -603,7 +604,8 @@ case class _withmin() extends Reporter {
 case class _withoutinterruption() extends Command {
   override def syntax =
     Syntax.commandSyntax(
-      right = List(Syntax.CommandBlockType))
+      right = List(Syntax.CommandBlockType),
+      introducesContext = true)
 }
 case class _xor() extends Reporter {
   override def syntax =

--- a/parser-core/src/main/core/prim/misc.scala
+++ b/parser-core/src/main/core/prim/misc.scala
@@ -69,7 +69,8 @@ case class _carefully() extends Command {
   val let: Let = Let()
   override def syntax =
     Syntax.commandSyntax(
-      right = List(Syntax.CommandBlockType, Syntax.CommandBlockType))
+      right = List(Syntax.CommandBlockType, Syntax.CommandBlockType),
+      introducesContext = true)
 }
 case class _commandtask(minArgCount: Int = 0) extends Reporter {
   override def syntax =

--- a/parser-core/src/main/parse/ControlFlowVerifier.scala
+++ b/parser-core/src/main/parse/ControlFlowVerifier.scala
@@ -12,9 +12,9 @@ import scala.collection.mutable.Stack
 class ControlFlowVerifier extends AstVisitor {
 
   sealed trait CurrentContext
-  case object ReporterContext                         extends CurrentContext
-  case object CommandContext                          extends CurrentContext
-  case object BlockContext                            extends CurrentContext
+  case object ReporterContext extends CurrentContext
+  case object CommandContext  extends CurrentContext
+  case object BlockContext    extends CurrentContext
 
   var contextStack = Stack[CurrentContext]()
 
@@ -32,6 +32,10 @@ class ControlFlowVerifier extends AstVisitor {
       case (ReporterContext, _: _stop) =>
         exception(
           I18N.errors.getN("org.nlogo.prim.etc._stop.notAllowedInsideToReport", "STOP"),
+          statement)
+      case (_, _: _report) if contextStack.contains(CommandContext) =>
+        exception(
+          I18N.errors.getN("org.nlogo.prim._report.canOnlyUseInToReport", "REPORT"),
           statement)
       case _ if (statement.command.syntax.blockAgentClassString.nonEmpty) =>
         contextStack.push(BlockContext)

--- a/parser-core/src/main/parse/ControlFlowVerifier.scala
+++ b/parser-core/src/main/parse/ControlFlowVerifier.scala
@@ -1,0 +1,44 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import org.nlogo.core.{ prim, AstVisitor, Fail, I18N, ProcedureDefinition, ReporterBlock, CommandBlock, Statement },
+  Fail._,
+  prim.etc.{ _report, _stop }
+
+
+import scala.collection.mutable.Stack
+
+class ControlFlowVerifier extends AstVisitor {
+
+  sealed trait CurrentContext
+  case object ReporterContext                         extends CurrentContext
+  case object CommandContext                          extends CurrentContext
+  case object BlockContext                            extends CurrentContext
+
+  var contextStack = Stack[CurrentContext]()
+
+  override def visitProcedureDefinition(proc: ProcedureDefinition) = {
+    if (proc.procedure.isReporter)
+      contextStack.push(ReporterContext)
+    else
+      contextStack.push(CommandContext)
+    super.visitProcedureDefinition(proc)
+    contextStack.pop()
+  }
+
+  override def visitStatement(statement: Statement) = {
+    (contextStack.head, statement.command) match {
+      case (ReporterContext, _: _stop) =>
+        exception(
+          I18N.errors.getN("org.nlogo.prim.etc._stop.notAllowedInsideToReport", "STOP"),
+          statement)
+      case _ if (statement.command.syntax.blockAgentClassString.nonEmpty) =>
+        contextStack.push(BlockContext)
+        super.visitStatement(statement)
+        contextStack.pop()
+      case _ =>
+        super.visitStatement(statement)
+    }
+  }
+}

--- a/parser-core/src/main/parse/ControlFlowVerifier.scala
+++ b/parser-core/src/main/parse/ControlFlowVerifier.scala
@@ -3,50 +3,73 @@
 package org.nlogo.parse
 
 import
-  org.nlogo.core.{ AstVisitor, CommandBlock, Fail, I18N,
-                   prim, ProcedureDefinition, ReporterBlock, Statement },
+  org.nlogo.core.{ AstTransformer, CommandBlock, Fail, I18N,
+                   prim, ProcedureDefinition, ReporterBlock, Statement, Statements },
     Fail._,
-    prim.etc.{ _report, _stop }
+    prim.etc.{ _report, _run, _stop }
 
 import
   scala.collection.mutable.Stack
 
-class ControlFlowVerifier extends AstVisitor {
+class ControlFlowVerifier extends AstTransformer {
 
-  sealed trait CurrentContext
-  case object ReporterContext extends CurrentContext
-  case object CommandContext  extends CurrentContext
-  case object BlockContext    extends CurrentContext
-
-  var contextStack = Stack[CurrentContext]()
-
-  override def visitProcedureDefinition(proc: ProcedureDefinition) = {
-    if (proc.procedure.isReporter)
-      contextStack.push(ReporterContext)
-    else
-      contextStack.push(CommandContext)
-    super.visitProcedureDefinition(proc)
-    contextStack.pop()
+  sealed trait CurrentContext {
+    def nonLocalExit: Boolean
+    def exitsNonLocally: CurrentContext
   }
 
-  override def visitStatement(statement: Statement) = {
+  case class ReporterContext(nonLocalExit: Boolean = true) extends CurrentContext {
+    def exitsNonLocally = copy(true)
+  }
+  case class CommandContext(nonLocalExit: Boolean)         extends CurrentContext {
+    def exitsNonLocally = copy(true)
+  }
+  case class BlockContext(nonLocalExit: Boolean)           extends CurrentContext {
+    def exitsNonLocally = copy(true)
+  }
+
+  val contextStack = Stack[CurrentContext]()
+
+  override def visitProcedureDefinition(proc: ProcedureDefinition): ProcedureDefinition = {
+    if (proc.procedure.isReporter)
+      contextStack.push(new ReporterContext())
+    else
+      contextStack.push(CommandContext(false))
+    val p = super.visitProcedureDefinition(proc)
+    val ctx = contextStack.pop()
+    p.copy(
+      statements = p.statements.copy(nonLocalExit = ctx.nonLocalExit))
+  }
+
+  override def visitStatement(statement: Statement): Statement = {
+    if (statement.command.isInstanceOf[_report] ||
+      statement.command.isInstanceOf[_stop]     ||
+      statement.command.isInstanceOf[_run])
+      contextStack.update(0, contextStack.head.exitsNonLocally)
     (contextStack.head, statement.command) match {
-      case (ReporterContext, _: _stop) =>
+      case (_: ReporterContext, _: _stop) =>
         exception(
           I18N.errors.getN("org.nlogo.prim.etc._stop.notAllowedInsideToReport", "STOP"),
           statement)
-      case (_,               _: _report) if contextStack.contains(CommandContext) =>
+      case (_,                  _: _report) if contextStack.last.isInstanceOf[CommandContext] =>
         exception(
           I18N.errors.getN("org.nlogo.prim._report.canOnlyUseInToReport", "REPORT"),
           statement)
-      case (ctx,             _: _report) if ctx != ReporterContext =>
+      case ((_: BlockContext | _: CommandContext), _: _report) =>
         exception(
           I18N.errors.getN("org.nlogo.prim._report.mustImmediatelyBeUsedInToReport", "REPORT"),
           statement)
       case _ if (statement.command.syntax.introducesContext) =>
-        contextStack.push(BlockContext)
-        super.visitStatement(statement)
-        contextStack.pop()
+        contextStack.push(BlockContext(false))
+        val r = super.visitStatement(statement)
+        val context = contextStack.pop()
+        val newArgs = statement.args.map {
+          case c: CommandBlock => c.copy(
+            statements = c.statements.copy(
+              nonLocalExit = context.nonLocalExit))
+          case other           => other
+        }
+        r.copy(args = newArgs)
       case _ =>
         super.visitStatement(statement)
     }

--- a/parser-core/src/main/parse/ControlFlowVerifier.scala
+++ b/parser-core/src/main/parse/ControlFlowVerifier.scala
@@ -2,12 +2,14 @@
 
 package org.nlogo.parse
 
-import org.nlogo.core.{ prim, AstVisitor, Fail, I18N, ProcedureDefinition, ReporterBlock, CommandBlock, Statement },
-  Fail._,
-  prim.etc.{ _report, _stop }
+import
+  org.nlogo.core.{ AstVisitor, CommandBlock, Fail, I18N,
+                   prim, ProcedureDefinition, ReporterBlock, Statement },
+    Fail._,
+    prim.etc.{ _report, _stop }
 
-
-import scala.collection.mutable.Stack
+import
+  scala.collection.mutable.Stack
 
 class ControlFlowVerifier extends AstVisitor {
 
@@ -33,11 +35,15 @@ class ControlFlowVerifier extends AstVisitor {
         exception(
           I18N.errors.getN("org.nlogo.prim.etc._stop.notAllowedInsideToReport", "STOP"),
           statement)
-      case (_, _: _report) if contextStack.contains(CommandContext) =>
+      case (_,               _: _report) if contextStack.contains(CommandContext) =>
         exception(
           I18N.errors.getN("org.nlogo.prim._report.canOnlyUseInToReport", "REPORT"),
           statement)
-      case _ if (statement.command.syntax.blockAgentClassString.nonEmpty) =>
+      case (ctx,             _: _report) if ctx != ReporterContext =>
+        exception(
+          I18N.errors.getN("org.nlogo.prim._report.mustImmediatelyBeUsedInToReport", "REPORT"),
+          statement)
+      case _ if (statement.command.syntax.introducesContext) =>
         contextStack.push(BlockContext)
         super.visitStatement(statement)
         contextStack.pop()

--- a/parser-core/src/main/parse/FrontEnd.scala
+++ b/parser-core/src/main/parse/FrontEnd.scala
@@ -68,9 +68,9 @@ trait FrontEndMain {
     topLevelDefs.foreach(verifier.visitProcedureDefinition)
 
     val cfVerifier = new ControlFlowVerifier
-    topLevelDefs.foreach(cfVerifier.visitProcedureDefinition)
+    val verifiedDefs = topLevelDefs.map(cfVerifier.visitProcedureDefinition)
 
-    (topLevelDefs, structureResults)
+    (verifiedDefs, structureResults)
   }
 
   private def transformers: Seq[AstTransformer] = {

--- a/parser-core/src/main/parse/FrontEnd.scala
+++ b/parser-core/src/main/parse/FrontEnd.scala
@@ -67,6 +67,9 @@ trait FrontEndMain {
     val verifier = new TaskVariableVerifier
     topLevelDefs.foreach(verifier.visitProcedureDefinition)
 
+    val cfVerifier = new ControlFlowVerifier
+    topLevelDefs.foreach(cfVerifier.visitProcedureDefinition)
+
     (topLevelDefs, structureResults)
   }
 

--- a/parser-jvm/src/test/parse/ControlFlowVerifierTest.scala
+++ b/parser-jvm/src/test/parse/ControlFlowVerifierTest.scala
@@ -1,0 +1,104 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.parse
+
+import
+  org.nlogo.core.{ Command, CommandBlock, CompilerException, Expression, FrontEndProcedure, prim,
+    ProcedureDefinition, Statement, Statements, StructureDeclarations, Token },
+    prim.{ _ask, _carefully, _createturtles => _crt, etc, _fd },
+      etc.{ _die, _foreach, _if, _ifelse, _report, _run, _stop }
+
+import
+  org.scalacheck.Gen
+
+import
+  org.scalatest.{ FunSuite, prop, PropSpec },
+    prop.GeneratorDrivenPropertyChecks
+
+class ControlFlowVerifierTest extends FunSuite with GeneratorDrivenPropertyChecks {
+
+  test("no stop in command marks procedure as local-exit-only") {
+    forAll(generateProcedure(genNestingPrim, genericPrim)) { pd =>
+      val newPd = (new ControlFlowVerifier).visitProcedureDefinition(pd)
+      assert(! newPd.nonLocalExit)
+    }
+  }
+
+  test("stop in command marks procedure as non-local exit") {
+    forAll(generateProcedure(genNestingPrim, commandNonLocalExits)) { pd =>
+      val newPd = (new ControlFlowVerifier).visitProcedureDefinition(pd)
+      assert(newPd.nonLocalExit)
+      assert(newPd.statements.nonLocalExit)
+      assert(! newPd.statements.stmts.head
+        .args.headOption.map(_.asInstanceOf[CommandBlock].statements.nonLocalExit)
+        .getOrElse(false))
+    }
+  }
+
+  test("stop in context does not mark procedure as non-local exit") {
+    forAll(nestedStatements(genContextPrim, commandNonLocalExits).map(procdef(false))) { pd =>
+      val newPd = (new ControlFlowVerifier).visitProcedureDefinition(pd)
+      assert(! newPd.nonLocalExit)
+    }
+  }
+
+  test("reporter procedures are non-local exit") {
+    forAll(generateProcedure(genNestingPrim, Gen.const(_report()), true)) { pd =>
+      val newPd = (new ControlFlowVerifier).visitProcedureDefinition(pd)
+      assert(newPd.nonLocalExit)
+      assert(newPd.statements.nonLocalExit)
+    }
+  }
+
+  def stmt(prim: Command, args: Expression*) =
+    new Statement(prim, 0, 0, "foo.nlogo", args)
+
+  val genNestingPrim: Gen[Command] =
+    Gen.oneOf(_if(), _ifelse(), _foreach())
+
+  val genContextPrim: Gen[Command] =
+    Gen.oneOf(_ask(), _carefully())
+
+  //prims that are none of nesting, non-local-exit, nor context-creating
+  val genericPrim: Gen[Command] =
+    Gen.oneOf(_die(), _crt("TURTLE"), _fd())
+
+  val commandNonLocalExits =
+    Gen.oneOf(_stop(), _run())
+
+  def statements(stmts: Seq[Statement]): Statements =
+    new Statements("abc").copy(stmts = stmts)
+
+  def generateProcedure(ctxPrimGen: Gen[Command], nestedPrimGen: Gen[Command], isReporter: Boolean = false): Gen[ProcedureDefinition] =
+    Gen.oneOf(
+      nestedPrimGen.map(p => statements(Seq(stmt(p)))),
+      nestedStatements(ctxPrimGen, nestedPrimGen))
+        .map(procdef(isReporter))
+
+  def nestedStatements(ctxPrimGen: Gen[Command], nestedPrimGen: Gen[Command]): Gen[Statements] = {
+    def commandBlock(stmts: Statements): CommandBlock =
+      new CommandBlock(stmts, 0, 0, "abc")
+
+    def inBlockContext(ctxPrim: Command, block: Statements): Statements =
+      statements(Seq(stmt(ctxPrim, commandBlock(block))))
+
+    for {
+      ctxPrim <- ctxPrimGen
+      nPrim   <- nestedPrimGen
+    } yield inBlockContext(ctxPrim, statements(Seq(stmt(nPrim))))
+  }
+
+  def procdef(isReporter: Boolean)(statements: Statements): ProcedureDefinition =
+    new ProcedureDefinition(frontEndProcedure(isReporter), statements)
+
+  def frontEndProcedure(reporterProcedure: Boolean): FrontEndProcedure = new FrontEndProcedure {
+    def procedureDeclaration: StructureDeclarations.Procedure = ???
+    def name: String = "foobar"
+    def isReporter: Boolean = reporterProcedure
+    def displayName: String = "foobar"
+    def filename: String = "foo.nlogo"
+    def nameToken: Token = ???
+    def argTokens: Seq[Token] = Seq()
+    def dump: String = "TEST FRONTENDPROCEDURE"
+  }
+}


### PR DESCRIPTION
```NetLogo
to-report foo
  stop
  report "foo"
end
```
always compiles, but always errors when run. This needs to take into account that 
```NetLogo
to-report foo
  ask turtles [ stop ]
  report 0
end
```
is valid.