### PR TITLE
Weird error messages when having several lines with missing closing quotation marks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val commonSettings = Seq(
     "-deprecation -unchecked -feature -Xcheckinit -encoding us-ascii -target:jvm-1.7 -Xlint -Xfatal-warnings"
       .split(" ").toSeq,
   scalaSource in Compile := baseDirectory.value / "src" / "main",
-  scalaSource in Test := baseDirectory.value / "src" / "test",
+  scalaSource in Test    := baseDirectory.value / "src" / "test",
   ivyLoggingLevel := UpdateLogging.Quiet,
   logBuffered in testOnly in Test := false,
   onLoadMessage := "",
@@ -88,8 +88,7 @@ lazy val docOptions = Seq(
 lazy val parserSettings: Seq[Setting[_]] = Seq(
   isSnapshot := true,
   name := "parser",
-  version := "0.0.1",
-  unmanagedSourceDirectories in Compile += file(".").getAbsoluteFile / "parser-core" / "src" / "main"
+  version := "0.0.1"
 )
 
 lazy val root = project.in(file("."))
@@ -113,7 +112,7 @@ lazy val parser = CrossProject("parser", file("."),
     override def projectDir(crossBase: File, projectType: String): File =
       crossBase / s"parser-$projectType"
     override def sharedSrcDir(projectBase: File, conf: String): Option[File] =
-      Some(projectBase / "parser-core" / "src" / conf)
+      Some(projectBase.getParentFile / "parser-core" / "src" / conf)
   }).
   settings(commonSettings: _*).
   settings(parserSettings: _*).

--- a/parser-core/src/main/lex/TokenLexer.scala
+++ b/parser-core/src/main/lex/TokenLexer.scala
@@ -81,10 +81,11 @@ class TokenLexer {
 
   def stringLexer: LexPredicate =
     withFeedback[Option[Char]](Some('"')) {
-      case (Some('\\'), '"') => (Some('"'), Accept)
-      case (Some('\\'), '\\') => (None, Accept)
-      case (_, '"') => (Some('"'), Finished)
-      case (_, c) => (Some(c), Accept)
+      case (Some('\\'), '"')  => (Some('"'), Accept)
+      case (Some('\\'), '\\') => (None,      Accept)
+      case (_, '"')           => (Some('"'), Finished)
+      case (_, '\n')          => (None,      Error)
+      case (_, c)             => (Some(c),   Accept)
     }
 
   def comment: (LexPredicate, TokenGenerator) =

--- a/parser-core/src/test/lex/LexerTestCases.scala
+++ b/parser-core/src/test/lex/LexerTestCases.scala
@@ -17,9 +17,23 @@ object LexerTestCases {
   val SuccessCases = Seq(
     LexSuccess("", ""),
     LexSuccess("\n", ""),
-    LexSuccess(".5", "Token(.5,Literal,0.5)"),
-    LexSuccess("-1", "Token(-1,Literal,-1.0)", "Token(-1,Literal,-1)"),
-    LexSuccess("-.75", "Token(-.75,Literal,-0.75)"),
+    LexSuccess(".5",         "Token(.5,Literal,0.5)"),
+    LexSuccess("-1",         "Token(-1,Literal,-1.0)", "Token(-1,Literal,-1)"),
+    LexSuccess("-.75",       "Token(-.75,Literal,-0.75)"),
+    LexSuccess("foo",        "Token(foo,Ident,FOO)"),
+    LexSuccess("_",          "Token(_,Ident,_)"),
+    LexSuccess("\"foo\"",    "Token(\"foo\",Literal,foo)"),
+    LexSuccess("""""""",     "Token(\"\",Literal,)"),
+    LexSuccess(""""\"\""""", "Token(\"\\\"\\\"\",Literal,\"\")"),
+    LexSuccess("\"\\\\\"",   "Token(\"\\\\\",Literal,\\)"),
+    LexSuccess("round ?",    "Token(round,Ident,ROUND)Token(?,Ident,?)"),
+    LexSuccess("a\rb",       "Token(a,Ident,A)" + "Token(b,Ident,B)"),
+    LexSuccess("-.",         "Token(-.,Ident,-.)"),
+    { val o ="\u00F6"  // lower case o with umlaut
+      LexSuccess(o, s"Token($o,Ident,${o.toUpperCase})") },
+    LexSuccess("\"foo\u216C\"", "Token(\"foo\u216C\",Literal,foo\u216C)"),
+    LexSuccess("-WOLF-SHAPE-00013",
+      "Token(-WOLF-SHAPE-00013,Ident,-WOLF-SHAPE-00013)"),
     LexSuccess("__ignore round 0.5",
       "Token(__ignore,Ident,__IGNORE)" +
         "Token(round,Ident,ROUND)" +
@@ -32,24 +46,7 @@ object LexerTestCases {
       "Token(__ignore,Ident,__IGNORE)" +
         "Token(round,Ident,ROUND)" +
         "Token(0.5,Literal,0.5)"),
-    LexSuccess("foo", "Token(foo,Ident,FOO)"),
-    LexSuccess("_", "Token(_,Ident,_)"),
-    LexSuccess("round ?",
-      "Token(round,Ident,ROUND)" +
-        "Token(?,Ident,?)"),
-    LexSuccess("\"foo\"", "Token(\"foo\",Literal,foo)"),
-    LexSuccess("""""""",  "Token(\"\",Literal,)"),
-    LexSuccess(""""\"\""""", "Token(\"\\\"\\\"\",Literal,\"\")"),
-    LexSuccess("\"\\\\\"", "Token(\"\\\\\",Literal,\\)"),
-    LexSuccess("a\rb", "Token(a,Ident,A)" + "Token(b,Ident,B)"),
-    { val o ="\u00F6"  // lower case o with umlaut
-      LexSuccess(o, s"Token($o,Ident,${o.toUpperCase})") },
-    LexSuccess("\"foo\u216C\"", "Token(\"foo\u216C\",Literal,foo\u216C)"),
-    LexSuccess("-WOLF-SHAPE-00013",
-      "Token(-WOLF-SHAPE-00013,Ident,-WOLF-SHAPE-00013)"),
-    LexSuccess("-.", "Token(-.,Ident,-.)"),
-    {
-      val tokens =
+    { val tokens =
         """|Token([,OpenBracket,null)
            |Token(123,Literal,123.0)
            |Token(-456,Literal,-456.0)
@@ -63,18 +60,19 @@ object LexerTestCases {
   )
 
   val FailureCases = Seq(
-    LexFailure("\"\\b\"", 0, 4, "Illegal character after backslash"),
-    LexFailure("\"\\\"", 0, 3, "Closing double quote is missing"),
-    LexFailure(""""abc""", 0, 4, "Closing double quote is missing"),
-    LexFailure("1.2.3", 0, 5, "Illegal number format"),
-    LexFailure("__ignore 3__ignore 4", 9, 18, "Illegal number format"),
+    LexFailure("\"\\b\"",      0, 4,  "Illegal character after backslash"),
+    LexFailure("\"\\\"",       0, 3,  "Closing double quote is missing"),
+    LexFailure(""""abc""",     0, 4,  "Closing double quote is missing"),
+    LexFailure("\"abc\n\"",    0, 4,  "Closing double quote is missing"),
+    LexFailure("1.2.3",        0, 5,  "Illegal number format"),
     LexFailure("{{array: 1: ", 0, 12, "End of file reached unexpectedly"),
-    LexFailure("{{", 0, 2, "End of file reached unexpectedly"),
-    LexFailure("{{\n", 0, 3, "End of line reached unexpectedly"),
-    LexFailure("{{ {{ }}", 0, 8, "End of file reached unexpectedly"),
+    LexFailure("{{",           0, 2,  "End of file reached unexpectedly"),
+    LexFailure("{{\n",         0, 3,  "End of line reached unexpectedly"),
+    LexFailure("{{ {{ }}",     0, 8,  "End of file reached unexpectedly"),
     // 216C is a Unicode character I chose pretty much at random.  it's a Roman numeral
     // for fifty, and *looks* just like an L, but is not a letter according to Unicode.
-    LexFailure("foo\u216Cbar", 3, 4, "This non-standard character is not allowed.")
+    LexFailure("foo\u216Cbar", 3, 4,  "This non-standard character is not allowed."),
+    LexFailure("__ignore 3__ignore 4", 9, 18, "Illegal number format")
   )
 
   val WsSkippingCases = Seq(

--- a/parser-core/src/test/lex/LexerTestCases.scala
+++ b/parser-core/src/test/lex/LexerTestCases.scala
@@ -1,0 +1,86 @@
+// (C) Uri Wilensky. https://github.com/NetLogo/NetLogo
+
+package org.nlogo.lex
+
+object LexerTestCases {
+
+  case class LexFailure(text: String, start: Int, end: Int, error: String)
+  case class LexSuccess(text: String, tokens: String, jsTokens: String)
+  case class WsSkip(text: String, expectedTokenTexts: Seq[String], expectedSkips: Seq[Int])
+
+  object LexSuccess {
+    // in most cases, the tokens are exactly the same
+    def apply(text: String, tokens: String): LexSuccess =
+      LexSuccess(text, tokens, tokens)
+  }
+
+  val SuccessCases = Seq(
+    LexSuccess("", ""),
+    LexSuccess("\n", ""),
+    LexSuccess(".5", "Token(.5,Literal,0.5)"),
+    LexSuccess("-1", "Token(-1,Literal,-1.0)", "Token(-1,Literal,-1)"),
+    LexSuccess("-.75", "Token(-.75,Literal,-0.75)"),
+    LexSuccess("__ignore round 0.5",
+      "Token(__ignore,Ident,__IGNORE)" +
+        "Token(round,Ident,ROUND)" +
+        "Token(0.5,Literal,0.5)"),
+    LexSuccess("\n\n__ignore round 0.5",
+      "Token(__ignore,Ident,__IGNORE)" +
+        "Token(round,Ident,ROUND)" +
+        "Token(0.5,Literal,0.5)"),
+    LexSuccess("\r__ignore round 0.5",
+      "Token(__ignore,Ident,__IGNORE)" +
+        "Token(round,Ident,ROUND)" +
+        "Token(0.5,Literal,0.5)"),
+    LexSuccess("foo", "Token(foo,Ident,FOO)"),
+    LexSuccess("_", "Token(_,Ident,_)"),
+    LexSuccess("round ?",
+      "Token(round,Ident,ROUND)" +
+        "Token(?,Ident,?)"),
+    LexSuccess("\"foo\"", "Token(\"foo\",Literal,foo)"),
+    LexSuccess("""""""",  "Token(\"\",Literal,)"),
+    LexSuccess(""""\"\""""", "Token(\"\\\"\\\"\",Literal,\"\")"),
+    LexSuccess("\"\\\\\"", "Token(\"\\\\\",Literal,\\)"),
+    LexSuccess("a\rb", "Token(a,Ident,A)" + "Token(b,Ident,B)"),
+    { val o ="\u00F6"  // lower case o with umlaut
+      LexSuccess(o, s"Token($o,Ident,${o.toUpperCase})") },
+    LexSuccess("\"foo\u216C\"", "Token(\"foo\u216C\",Literal,foo\u216C)"),
+    LexSuccess("-WOLF-SHAPE-00013",
+      "Token(-WOLF-SHAPE-00013,Ident,-WOLF-SHAPE-00013)"),
+    LexSuccess("-.", "Token(-.,Ident,-.)"),
+    {
+      val tokens =
+        """|Token([,OpenBracket,null)
+           |Token(123,Literal,123.0)
+           |Token(-456,Literal,-456.0)
+           |Token("a",Literal,a)
+           |Token(],CloseBracket,null)""".stripMargin.replaceAll("\n", "")
+    LexSuccess("[123 -456 \"a\"]", tokens, tokens.replaceAll(".0", "")) },
+    LexSuccess("{{array: 0}}", "Token({{array: 0}},Extension,{{array: 0}})"),
+    LexSuccess("{{array: 2: {{array: 0}} {{array: 1}}}}",
+      "Token({{array: 2: {{array: 0}} {{array: 1}}}},Extension," +
+        "{{array: 2: {{array: 0}} {{array: 1}}}})")
+  )
+
+  val FailureCases = Seq(
+    LexFailure("\"\\b\"", 0, 4, "Illegal character after backslash"),
+    LexFailure("\"\\\"", 0, 3, "Closing double quote is missing"),
+    LexFailure(""""abc""", 0, 4, "Closing double quote is missing"),
+    LexFailure("1.2.3", 0, 5, "Illegal number format"),
+    LexFailure("__ignore 3__ignore 4", 9, 18, "Illegal number format"),
+    LexFailure("{{array: 1: ", 0, 12, "End of file reached unexpectedly"),
+    LexFailure("{{", 0, 2, "End of file reached unexpectedly"),
+    LexFailure("{{\n", 0, 3, "End of line reached unexpectedly"),
+    LexFailure("{{ {{ }}", 0, 8, "End of file reached unexpectedly"),
+    // 216C is a Unicode character I chose pretty much at random.  it's a Roman numeral
+    // for fifty, and *looks* just like an L, but is not a letter according to Unicode.
+    LexFailure("foo\u216Cbar", 3, 4, "This non-standard character is not allowed.")
+  )
+
+  val WsSkippingCases = Seq(
+    WsSkip("    123",     Seq("123"),        Seq(4)),
+    WsSkip("123",         Seq("123"),        Seq(0)),
+    WsSkip("123   ",      Seq("123"),        Seq(3)),
+    WsSkip("  123   ",    Seq("123"),        Seq(5)),
+    WsSkip("  123  456 ", Seq("123", "456"), Seq(4, 1)))
+}

--- a/parser-js/src/test/lex/TokenizerTests.scala
+++ b/parser-js/src/test/lex/TokenizerTests.scala
@@ -8,20 +8,20 @@ import org.nlogo.core.{ Token, TokenType }
 object TokenizerTests extends TestSuite {
   def tests = TestSuite{
 
-    def tokenize(s: String) = {
+    def tokenize(s: String): Seq[Token] = {
       val result = Tokenizer.tokenizeString(s, "").toSeq
       assert(TokenType.Eof == result.last.tpe)
       result.dropRight(1)
     }
 
-    def tokenizeSkippingWhitespace(s: String) = {
+    def tokenizeSkippingWhitespace(s: String): Seq[(Token, Int)] = {
       val result = Tokenizer.tokenizeSkippingTrailingWhitespace(
         new java.io.StringReader(s), "").toSeq
       assert(TokenType.Eof == result.last._1.tpe)
       result.dropRight(1)
     }
 
-    def tokenizeRobustly(s: String) = {
+    def tokenizeRobustly(s: String): Seq[Token] = {
       val result = Tokenizer.tokenizeString(s, "").toList
       assert(TokenType.Eof == result.last.tpe)
       result.dropRight(1)
@@ -42,7 +42,8 @@ object TokenizerTests extends TestSuite {
       LexerTestCases.FailureCases foreach {
         case LexerTestCases.LexFailure(text, start, end, error) =>
           val tokens = tokenizeRobustly(text)
-          val badToken = firstBadToken(tokens).get
+          val badToken = firstBadToken(tokens).getOrElse(
+            throw new Exception(s"Expected bad token, got ${tokens.mkString}"))
           assert(start == badToken.start)
           assert(end   == badToken.end)
           assert(error == badToken.value)

--- a/parser-jvm/src/test/lex/TokenizerTests.scala
+++ b/parser-jvm/src/test/lex/TokenizerTests.scala
@@ -7,7 +7,7 @@ import org.nlogo.core.{ Token, TokenType }
 
 class TokenizerTests extends FunSuite {
 
-  def tokenize(s: String) = {
+  def tokenize(s: String): Seq[Token] = {
     val result = Tokenizer.tokenizeString(s, "").toSeq
     assertResult(TokenType.Eof)(result.last.tpe)
     result.dropRight(1)
@@ -18,134 +18,42 @@ class TokenizerTests extends FunSuite {
     assertResult(TokenType.Eof)(result.last._1.tpe)
     result.dropRight(1)
   }
-  def tokenizeRobustly(s: String) = {
+  def tokenizeRobustly(s: String): List[Token] = {
     val result = Tokenizer.tokenize(new java.io.StringReader(s)).toList
     assertResult(TokenType.Eof)(result.last.tpe)
     result.dropRight(1)
   }
   def firstBadToken(tokens: Seq[Token]) =
     tokens.find(_.tpe == TokenType.Bad)
-  ///
-  test("TokenizeSimpleExpr") {
-    val expected =
-      "Token(__ignore,Ident,__IGNORE)" +
-        "Token(round,Ident,ROUND)" +
-        "Token(0.5,Literal,0.5)"
-    assertResult(expected)(
-      tokenize("__ignore round 0.5").mkString)
-  }
-  test("TokenizeSimpleExprWithInitialWhitespace") {
-    val tokens = tokenize("\n\n__ignore round 0.5")
-    val expected =
-      "Token(__ignore,Ident,__IGNORE)" +
-        "Token(round,Ident,ROUND)" +
-        "Token(0.5,Literal,0.5)"
-    assertResult(expected)(tokens.mkString)
-  }
-  test("TokenizeSimpleExprWithInitialReturn") {
-    val tokens = tokenize("\r__ignore round 0.5")
-    val expected =
-      "Token(__ignore,Ident,__IGNORE)" +
-        "Token(round,Ident,ROUND)" +
-        "Token(0.5,Literal,0.5)"
-    assertResult(expected)(tokens.mkString)
-  }
-  test("TokenizeIdent") {
-    val tokens = tokenize("foo")
-    val expected = "Token(foo,Ident,FOO)"
-    assertResult(expected)(tokens.mkString)
-  }
-  test("TokenizeQuestionMark") {
-    val tokens = tokenize("round ?")
-    val expected =
-      "Token(round,Ident,ROUND)" +
-        "Token(?,Ident,?)"
-    assertResult(expected)(tokens.mkString)
-  }
-  test("TokenizeString") {
-    val tokens = tokenize("\"foo\"")
-    val expected = "Token(\"foo\",Literal,foo)"
-    assertResult(expected)(tokens.mkString)
-  }
-  test("TokenizeEmptyString") {
-    val tokens = tokenize("""""""")
-    val expected = "Token(\"\",Literal,)"
-    assertResult(expected)(tokens.mkString)
-  }
-  test("TokenizeStringOfEmptyString") {
-    val tokens = tokenize(""""\"\""""")
-    val expected = "Token(\"\\\"\\\"\",Literal,\"\")"
-    assertResult(expected)(tokens.mkString)
-  }
-  test("TokenizeUnknownEscape") {
-    val tokens = tokenizeRobustly("\"\\b\"")
-    assertResult(0)(firstBadToken(tokens).get.start)
-    assertResult(4)(firstBadToken(tokens).get.end)
-    assertResult("Illegal character after backslash")(
-      firstBadToken(tokens).get.value)
-  }
-  test("TokenizeWeirdCaseWithBackSlash") {
-    val tokens = tokenizeRobustly("\"\\\"")
-    assertResult(0)(firstBadToken(tokens).get.start)
-    assertResult(3)(firstBadToken(tokens).get.end)
-    assertResult("Closing double quote is missing")(
-      firstBadToken(tokens).get.value)
-  }
-  test("TokenizeEscapedBackslash") {
-    val tokens = tokenize("\"\\\\\"")
-    assertResult("Token(\"\\\\\",Literal,\\)")(tokens.mkString)
-  }
-  test("TokenizeBadNumberFormat1") {
-    val tokens = tokenizeRobustly("1.2.3")
-    assertResult(0)(firstBadToken(tokens).get.start)
-    assertResult(5)(firstBadToken(tokens).get.end)
-    assertResult("Illegal number format")(
-      firstBadToken(tokens).get.value)
+
+  LexerTestCases.SuccessCases foreach {
+    case LexerTestCases.LexSuccess(text, expectedTokens, _) =>
+      test(s"""Tokenize: '$text'""") {
+        val tokens = tokenize(text)
+        assertResult(expectedTokens)(tokens.mkString)
+      }
   }
 
-  test("TokenizeBadNumberFormat2") {
-    val tokens = tokenizeRobustly("__ignore 3__ignore 4")
-    assertResult(9)(firstBadToken(tokens).get.start)
-    assertResult(18)(firstBadToken(tokens).get.end)
-    assertResult("Illegal number format")(
-      firstBadToken(tokens).get.value)
+  LexerTestCases.FailureCases foreach {
+    case LexerTestCases.LexFailure(text, start, end, error) =>
+      test(s"""Tokenize as error: '$text'""") {
+        val tokens = tokenizeRobustly(text)
+        val badToken = firstBadToken(tokens).get
+        assertResult(start)(badToken.start)
+        assertResult(end)(badToken.end)
+        assertResult(error)(badToken.value)
+      }
   }
 
-  test("TokenizeIdentStartingWithDash") {
-    val tokens   = tokenizeRobustly("-WOLF-SHAPE-00013")
-    val expected = "Token(-WOLF-SHAPE-00013,Ident,-WOLF-SHAPE-00013)"
-    assertResult(expected)(tokens.mkString)
+  LexerTestCases.WsSkippingCases foreach {
+    case LexerTestCases.WsSkip(text, expectedTokenTexts, expectedSkips) =>
+      test(s"""Skips whitespace correctly: '$text'""") {
+        val tokens = tokenizeSkippingWhitespace(text)
+        assertResult(expectedTokenTexts)(tokens.map(_._1.text))
+        assertResult(expectedSkips     )(tokens.map(_._2))
+      }
   }
 
-  test("TokenizeLooksLikePotentialNumber") {
-    val tokens = tokenize("-.")
-    val expected = "Token(-.,Ident,-.)"
-    assertResult(expected)(tokens.mkString)
-  }
-
-  test("ListOfLiterals") {
-    val tokens = tokenize("[123 -456 \"a\"]")
-    val expected = """|Token([,OpenBracket,null)
-                      |Token(123,Literal,123.0)
-                      |Token(-456,Literal,-456.0)
-                      |Token("a",Literal,a)
-                      |Token(],CloseBracket,null)""".stripMargin.replaceAll("\n", "")
-    assertResult(expected)(tokens.mkString)
-
-  }
-
-  test("Empty1") {
-    val tokens = tokenize("")
-    assertResult("")(tokens.mkString)
-  }
-  test("Empty2") {
-    val tokens = tokenize("\n")
-    assertResult("")(tokens.mkString)
-  }
-  test("underscore") {
-    val tokens = tokenize("_")
-    assertResult("Token(_,Ident,_)")(tokens.mkString)
-  }
   test("ListOfArrays") {
     val tokens = tokenize("[{{array: 0}} {{array: 1}}]")
     assertResult("Token([,OpenBracket,null)" +
@@ -157,87 +65,5 @@ class TokenizerTests extends FunSuite {
     assertResult(13)(tokens(1).end)
     assertResult(14)(tokens(2).start)
     assertResult(26)(tokens(2).end)
-  }
-
-  test("ArrayOfArrays") {
-    val tokens = tokenize("{{array: 2: {{array: 0}} {{array: 1}}}}")
-    val expected = "Token({{array: 2: {{array: 0}} {{array: 1}}}},Extension," +
-      "{{array: 2: {{array: 0}} {{array: 1}}}})"
-    assertResult(expected)(tokens.mkString)
-  }
-
-  test("UnclosedExtensionLiteral1") {
-    val tokens = tokenizeRobustly("{{array: 1: ")
-    assertResult("Token(,Bad,End of file reached unexpectedly)")(
-      tokens.mkString)
-  }
-  test("UnclosedExtensionLiteral2") {
-    val tokens = tokenizeRobustly("{{")
-    assertResult("Token(,Bad,End of file reached unexpectedly)")(
-      tokens.mkString)
-  }
-  test("UnclosedExtensionLiteral3") {
-    val tokens = tokenizeRobustly("{{\n")
-    assertResult("Token(,Bad,End of line reached unexpectedly)")(
-      tokens.mkString)
-  }
-
-  test("carriageReturnsAreWhitespace") {
-    val tokens = tokenize("a\rb")
-    assertResult("Token(a,Ident,A)" + "Token(b,Ident,B)")(
-      tokens.mkString)
-  }
-
-  /// Unicode
-  test("unicode") {
-    val o ="\u00F6"  // lower case o with umlaut
-    val tokens = tokenize(o)
-    assertResult("Token(" + o + ",Ident," + o.toUpperCase + ")")(
-      tokens.mkString)
-  }
-  test("TokenizeBadCharactersInIdent") {
-    // 216C is a Unicode character I chose pretty much at random.  it's a Roman numeral
-    // for fifty, and *looks* just like an L, but is not a letter according to Unicode.
-    val tokens = tokenizeRobustly("foo\u216Cbar")
-    assertResult(3)(firstBadToken(tokens).get.start)
-    assertResult(4)(firstBadToken(tokens).get.end)
-    assertResult("This non-standard character is not allowed.")(
-      firstBadToken(tokens).get.value)
-  }
-  test("TokenizeOddCharactersInString") {
-    val tokens = tokenize("\"foo\u216C\"")
-    val expected = "Token(\"foo\u216C\",Literal,foo\u216C)"
-    assertResult(expected)(tokens.mkString)
-  }
-
-  test("TokenizeWithSkipWhitespaceSkipsBeginningWhitespace") {
-    val tokens = tokenizeSkippingWhitespace("    123")
-    assertResult("Token(123,Literal,123.0)")(tokens.head._1.toString)
-    assertResult(4)(tokens.head._2)
-  }
-  test("TokenizeWithSkipWhitespaceSkipsNoWhitespace") {
-    val tokens = tokenizeSkippingWhitespace("123")
-    assertResult("Token(123,Literal,123.0)")(tokens.head._1.toString)
-    assertResult(0)(tokens.head._2)
-  }
-
-  test("TokenizeWithSkipWhitespaceSkipsEndingWhitespace") {
-    val tokens = tokenizeSkippingWhitespace("123   ")
-    assertResult("Token(123,Literal,123.0)")(tokens.head._1.toString)
-    assertResult(3)(tokens.head._2)
-  }
-
-  test("TokenizeWithSkipWhitespaceSkipsBeginningAndEndWhitespace") {
-    val tokens = tokenizeSkippingWhitespace("  123   ")
-    assertResult("Token(123,Literal,123.0)")(tokens.head._1.toString)
-    assertResult(5)(tokens.head._2)
-  }
-
-  test("TokenizeWithSkipWhitespaceOnMultipleTokens") {
-    val tokens = tokenizeSkippingWhitespace("  123  456 ")
-    assertResult("Token(123,Literal,123.0)")(tokens(0)._1.toString)
-    assertResult(4)(tokens(0)._2)
-    assertResult("Token(456,Literal,456.0)")(tokens(1)._1.toString)
-    assertResult(1)(tokens(1)._2)
   }
 }

--- a/parser-jvm/src/test/lex/TokenizerTests.scala
+++ b/parser-jvm/src/test/lex/TokenizerTests.scala
@@ -38,7 +38,8 @@ class TokenizerTests extends FunSuite {
     case LexerTestCases.LexFailure(text, start, end, error) =>
       test(s"""Tokenize as error: '$text'""") {
         val tokens = tokenizeRobustly(text)
-        val badToken = firstBadToken(tokens).get
+        val badToken = firstBadToken(tokens).getOrElse(
+          fail(s"Expected bad token, got ${tokens.mkString}"))
         assertResult(start)(badToken.start)
         assertResult(end)(badToken.end)
         assertResult(error)(badToken.value)


### PR DESCRIPTION
_From @arthurhjorth on August 15, 2015 13:35_

edit: whoops, forgot to describe what caused this in the issue title. Fixed.

I was playing around with the Climate Change model in NLW yesterday, trying to break it, and ran into this weird... bug? Something. The result is that the error messages you get seem sort of random. I was playing around with the `setup` procedure, which looks like this:

```
to setup
  clear-all
  set-default-shape rays "ray"
  set-default-shape IRs "ray"
  set-default-shape clouds "cloud"
  set-default-shape heats "dot"
  set-default-shape CO2s "CO2-molecule"
  setup-world
  set temperature 12
  reset-ticks
end
```

If I remove the `"` in line 5 after cloud,  

```
to setup
  clear-all
  set-default-shape rays "ray"
  set-default-shape IRs "ray"
  set-default-shape clouds "cloud ;; removed closing quotation mark
  set-default-shape heats "dot"
  set-default-shape CO2s "CO2-molecule"
  setup-world
  set temperature 12
  reset-ticks
end
```
I get error message "Closing double quote is missing". So far so good.  I then removed the quotation mark in line 6 after dot, but accidentally removed the t too:

```
to setup
  clear-all
  set-default-shape rays "ray"
  set-default-shape IRs "ray"
  set-default-shape clouds "cloud ;; removed closing quotation mark
  set-default-shape heats "do ;; 't"' gone
  set-default-shape CO2s "CO2-molecule"
  setup-world
  set temperature 12
  reset-ticks
end
```
and then I get "Nothing named DO has been defined".

I tried to move the missing quotation mark up a line like this:
```
to setup
  clear-all
  set-default-shape rays "ray"
  set-default-shape IRs "ray
  set-default-shape clouds "cloud"
  set-default-shape heats "do
  set-default-shape CO2s "CO2-molecule"
  setup-world
  set temperature 12
  reset-ticks
end
```
but I get the same "Nothing named DO has been defined"-message.

In desktop NetLogo, if I do the exact same things, I correctly get the "Closing double quote is missing"-message.

_Copied from original issue: NetLogo/Galapagos#307_