### PR TITLE
upgrade to ScalaCheck 1.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val scalatestSettings = Seq(
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oT"),
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "2.2.4" % "test",
-    "org.scalacheck" %% "scalacheck" % "1.12.5" % "test"
+    "org.scalacheck" %% "scalacheck" % "1.13.0" % "test"
   )
 )
 


### PR DESCRIPTION
no special reason, just keeping current
